### PR TITLE
Add change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Move code over from the [AMP for WordPress plugin repository](https://github.com/ampproject/amp-wp) to the current new repository.
+- Add GitHub Actions workflow ([#2](https://github.com/ampproject/amp-toolbox-php/pull/2))
+- Add `PreloadHeroImage` transformer ([#7](https://github.com/ampproject/amp-toolbox-php/pull/7))
+- Add `LICENSE` file
+- Adapt license meta information in `composer.json` file
+- Add change log ([#8](https://github.com/ampproject/amp-toolbox-php/pull/8))


### PR DESCRIPTION
The project should contain a separate change log in the form of a `CHANGELOG.md` file, to make it easier for consumers of the library to keep on top of (breaking) changes.

This PR adds a change log based on the [keepachangelog](https://keepachangelog.com/) specification.