### PR TITLE
Rename Extension::IMAGE to Extension::IMG for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Added (relative to version transferred over from plugin)
 - Move code over from the [AMP for WordPress plugin repository](https://github.com/ampproject/amp-wp) to the current new repository.
 - Add GitHub Actions workflow ([#2](https://github.com/ampproject/amp-toolbox-php/pull/2))
 - Add `PreloadHeroImage` transformer ([#7](https://github.com/ampproject/amp-toolbox-php/pull/7))
 - Add `LICENSE` file
 - Adapt license meta information in `composer.json` file
 - Add change log ([#8](https://github.com/ampproject/amp-toolbox-php/pull/8))
+- Renamed `Extension::IMAGE` into `Extension::IMG` for consistency ([#21](https://github.com/ampproject/amp-toolbox-php/pull/21))

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -24,7 +24,7 @@ interface Extension
     const GEO                 = 'amp-geo';
     const GFYCAT              = 'amp-gfycat';
     const IFRAME              = 'amp-iframe';
-    const IMAGE               = 'amp-img';
+    const IMG                 = 'amp-img';
     const IMGUR               = 'amp-imgur';
     const INSTAGRAM           = 'amp-instagram';
     const MUSTACHE            = 'amp-mustache';

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -239,7 +239,7 @@ final class PreloadHeroImage implements Transformer
         }
 
         $src = $element->getAttribute(Attribute::SRC);
-        if ($element->tagName === Extension::IMAGE && Url::isValidNonDataUrl($src)) {
+        if ($element->tagName === Extension::IMG && Url::isValidNonDataUrl($src)) {
             return new HeroImage(
                 $src,
                 $element->getAttribute(Attribute::MEDIA),
@@ -286,7 +286,7 @@ final class PreloadHeroImage implements Transformer
             return null;
         }
 
-        if ($element->tagName === Extension::IMAGE || $element->tagName === Tag::IMG) {
+        if ($element->tagName === Extension::IMG || $element->tagName === Tag::IMG) {
             return $this->detectHeroImageCandidateForAmpImg($element);
         }
 
@@ -402,7 +402,7 @@ final class PreloadHeroImage implements Transformer
                 }
 
                 if (
-                    $placeholder->tagName === Extension::IMAGE
+                    $placeholder->tagName === Extension::IMG
                     || $placeholder->tagName === Tag::IMG
                 ) {
                     // Found valid candidate for placeholder image.
@@ -507,7 +507,7 @@ final class PreloadHeroImage implements Transformer
     {
         $element = $heroImage->getAmpImg();
 
-        if (! $element || $element->tagName !== Extension::IMAGE) {
+        if (! $element || $element->tagName !== Extension::IMG) {
             return;
         }
 


### PR DESCRIPTION
All extension names should be ported as is to their associated constants, for consistency reasons.

Fixes #5 