### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[0.1.0]](https://github.com/ampproject/amp-toolbox-php/releases/tag/0.1.0) - 2020-11-06
 ### Added
 - Move code over from the [AMP for WordPress plugin repository](https://github.com/ampproject/amp-wp) to the current new repository.
 - Add GitHub Actions workflow ([#2](https://github.com/ampproject/amp-toolbox-php/pull/2))
@@ -13,3 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `LICENSE` file
 - Adapt license meta information in `composer.json` file
 - Add change log ([#8](https://github.com/ampproject/amp-toolbox-php/pull/8))
+
+[Unreleased]: https://github.com/ampproject/amp-toolbox-php/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/ampproject/amp-toolbox-php/releases/tag/0.1.0


### PR DESCRIPTION
- Move code over from the [AMP for WordPress plugin repository](https://github.com/ampproject/amp-wp) to the current new repository.
- Add GitHub Actions workflow ([#2](https://github.com/ampproject/amp-toolbox-php/pull/2))
- Add `PreloadHeroImage` transformer ([#7](https://github.com/ampproject/amp-toolbox-php/pull/7))
- Add `LICENSE` file
- Adapt license meta information in `composer.json` file
- Add change log ([#8](https://github.com/ampproject/amp-toolbox-php/pull/8))
