### PR TITLE
Skip escaped slashes when normalizing self-closing tags

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -880,7 +880,7 @@ final class Document extends DOMDocument
         static $regexPattern = null;
 
         if (null === $regexPattern) {
-            $regexPattern = '#<(' . implode('|', Tag::SELF_CLOSING_TAGS) . ')([^>]*?)(?>\s*\/)?>(?!</\1>)#';
+            $regexPattern = '#<(' . implode('|', Tag::SELF_CLOSING_TAGS) . ')([^>]*?)(?>\s*(\/|\\\/))?>(?!</\1>)#';
         }
 
         $this->selfClosingTagsTransformed = true;

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -880,7 +880,7 @@ final class Document extends DOMDocument
         static $regexPattern = null;
 
         if (null === $regexPattern) {
-            $regexPattern = '#<(' . implode('|', Tag::SELF_CLOSING_TAGS) . ')([^>]*?)(?>\s*(\/|\\\/))?>(?!</\1>)#';
+            $regexPattern = '#<(' . implode('|', Tag::SELF_CLOSING_TAGS) . ')([^>]*?)(?>\s*(?<!\\\\)\/)?>(?!</\1>)#';
         }
 
         $this->selfClosingTagsTransformed = true;

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -355,15 +355,20 @@ class DocumentTest extends TestCase
                 ',
             ],
             'mustache_url_encoded_attributes_in_template_tags' => [
-              'utf-8',
+                'utf-8',
                 '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
             ],
             'mustache_url_encoded_attributes_in_script_tags' => [
-              'utf-8',
+                'utf-8',
                 '<!DOCTYPE html><html>' . $head . '<body><script type="text/plain" template="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></script></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><script type="text/plain" template="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></script></body></html>',
             ],
+            'schema_markup_check' => [
+                'utf-8',
+                '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>'
+            ]
         ];
     }
 

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -366,8 +366,28 @@ class DocumentTest extends TestCase
             ],
             'schema_markup_check' => [
                 'utf-8',
-                '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>',
-                '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>'
+                '
+                <!DOCTYPE html>
+                <html>
+                    <head><meta charset="utf-8"></head>
+                    <body>
+                    <script type="application/ld+json">
+                        {"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}
+                    </script>
+                    </body>
+                </html>
+                ',
+                '
+                <!DOCTYPE html>
+                <html>
+                    <head><meta charset="utf-8"></head>
+                    <body>
+                    <script type="application/ld+json">
+                        {"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}
+                    </script>
+                    </body>
+                </html>
+                '
             ],
             'self_closing_tag' => [
                 'utf-8',

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -368,7 +368,12 @@ class DocumentTest extends TestCase
                 'utf-8',
                 '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"LiveBlogPosting","url":"https:\/\/amp.dev\/documentation\/examples\/news-publishing\/live_blog\/","articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n","datePublished":"2016-09-08T23:04:28.24337"}</script></body></html></body></html>'
-            ]
+            ],
+            'self_closing_tag' => [
+                'utf-8',
+                '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><br/></body></html>',
+                '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><br></body></html>',
+            ],
         ];
     }
 


### PR DESCRIPTION
Hi!
We encountered a problem on our site, when for example for a live article, we'll have a json+ld script part like this:
```json
"articleBody":"<p><img class=\"aligncenter size-large wp-image-807214\" src=\"https:\/\/images.frandroid.com\/wp-content\/uploads\/2020\/11\/sonos-beam-1200x799.jpg\" alt=\"\" width=\"1200\" height=\"799\" \/><br \/><\/p>\n"
```
Let's take this simple `<br \/>`, the WordPress amp plugin will transform it to `<br \>` which cause a Google rich result validation errors, same thing for the `img` tag.

So, here is a fix that handle this sanitized slash and remove it while removing the normal self-closing slash.
Hope that's OK for you!
Cheers.