### PR TITLE
Raise PHPStan level to 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
 	# @see https://github.com/phpstan/phpstan-src/blob/b9f62d63f2deaa0a5e97f51073e41a422c48aa01/conf/bleedingEdge.neon
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 4
+	level: 5
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- src/

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1768,7 +1768,7 @@ final class Document extends DOMDocument
                 $ampCustomStyle = $this->xpath->query(self::XPATH_AMP_CUSTOM_STYLE_QUERY, $this->head)->item(0);
                 if (!$ampCustomStyle instanceof Element) {
                     $ampCustomStyle = $this->createElement(Tag::STYLE);
-                    $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
+                    $ampCustomStyle->appendChild($this->createAttribute(Attribute::AMP_CUSTOM));
                     $this->head->appendChild($ampCustomStyle);
                 }
 

--- a/src/Exception/FailedToGetFromRemoteUrl.php
+++ b/src/Exception/FailedToGetFromRemoteUrl.php
@@ -33,7 +33,7 @@ final class FailedToGetFromRemoteUrl extends RuntimeException implements FailedR
     {
         $message = "Failed to fetch the contents from the URL '{$url}' as it returned HTTP status {$status}.";
 
-        $exception = new self($message);
+        $exception             = new self($message);
         $exception->statusCode = $status;
 
         return $exception;
@@ -63,7 +63,7 @@ final class FailedToGetFromRemoteUrl extends RuntimeException implements FailedR
     {
         $message = "Failed to fetch the contents from the URL '{$url}': {$exception->getMessage()}.";
 
-        return new self($message, null, $exception);
+        return new self($message, 0, $exception);
     }
 
     /**

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -481,7 +481,7 @@ final class PreloadHeroImage implements Transformer
         $preload->setAttribute(Attribute::REL, Attribute::REL_PRELOAD);
         $preload->setAttribute(Attribute::HREF, $heroImage->getSrc());
         $preload->setAttribute(Attribute::AS_, RequestDestination::IMAGE);
-        $preload->setAttribute(Attribute::DATA_HERO, null);
+        $preload->appendChild($document->createAttribute(Attribute::DATA_HERO));
         if ($heroImage->getSrcset()) {
             $preload->setAttribute(Attribute::IMAGESRCSET, $heroImage->getSrcset());
             if ($img && $img->hasAttribute(Attribute::SIZES)) {
@@ -537,8 +537,8 @@ final class PreloadHeroImage implements Transformer
             }
         }
 
-        $element->setAttribute(Attribute::I_AMPHTML_SSR, null);
-        $element->setAttribute(Attribute::DATA_HERO, null);
+        $element->appendChild($document->createAttribute(Attribute::I_AMPHTML_SSR));
+        $element->appendChild($document->createAttribute(Attribute::DATA_HERO));
 
         $element->appendChild($imgElement);
 

--- a/src/RuntimeVersion.php
+++ b/src/RuntimeVersion.php
@@ -99,6 +99,6 @@ final class RuntimeVersion
      */
     private function padVersionString($version)
     {
-        return str_pad($version, 15, 0);
+        return str_pad($version, 15, '0');
     }
 }


### PR DESCRIPTION
This PR raises the PHPStan level to 5 and fixes the following issues:
- uses string `'0'` instead of int `0` as padding string
- uses `0` instead of `null` as default exception code
- uses `DOMDocument::createAttribute()` to create attributes without a value

Fixes #16 