### PR TITLE
Fix @covers annotations

### DIFF
--- a/tests/AmpTest.php
+++ b/tests/AmpTest.php
@@ -10,7 +10,7 @@ use DOMNode;
 /**
  * Tests for AmpProject\Amp.
  *
- * @covers Amp
+ * @covers \AmpProject\Amp
  * @package ampproject/amp-toolbox
  */
 class AmpTest extends TestCase
@@ -40,7 +40,7 @@ class AmpTest extends TestCase
      * Test the check for an AMP runtime method.
      *
      * @dataProvider dataIsRuntimeScript
-     * @covers       Amp::isRuntimeScript()
+     * @covers       \AmpProject\Amp::isRuntimeScript()
      *
      * @param DOMNode $node     Node to check.
      * @param bool    $expected Expected boolean result.
@@ -72,7 +72,7 @@ class AmpTest extends TestCase
      * Test the check for an AMP runtime method.
      *
      * @dataProvider dataIsViewerScript
-     * @covers       Amp::isViewerScript()
+     * @covers       \AmpProject\Amp::isViewerScript()
      *
      * @param DOMNode $node     Node to check.
      * @param bool    $expected Expected boolean result.
@@ -106,7 +106,7 @@ class AmpTest extends TestCase
      * Test the render delaying check method.
      *
      * @dataProvider dataIsRenderDelayingExtension
-     * @covers       Amp::isRenderDelayingExtension()
+     * @covers       \AmpProject\Amp::isRenderDelayingExtension()
      *
      * @param DOMNode $node     Node to check
      * @param bool    $expected Expected boolean result.
@@ -137,7 +137,7 @@ class AmpTest extends TestCase
      * Test the check whether a given node is an AMP custom element.
      *
      * @dataProvider dataIsCustomElement
-     * @covers       Amp::isCustomElement()
+     * @covers       \AmpProject\Amp::isCustomElement()
      *
      * @param DOMNode $node     Node to check
      * @param bool    $expected Expected boolean result.
@@ -175,7 +175,7 @@ class AmpTest extends TestCase
      * Test the retrieval of an extension's name.
      *
      * @dataProvider dataExtensionTests
-     * @covers       Amp::getExtensionName()
+     * @covers       \AmpProject\Amp::getExtensionName()
      *
      * @param DOMNode $node     Node to get the name of.
      * @param string  $expected Expected string result.
@@ -190,7 +190,7 @@ class AmpTest extends TestCase
      * Test the check whether a node is an extension.
      *
      * @dataProvider dataExtensionTests
-     * @covers       Amp::isExtension()
+     * @covers       \AmpProject\Amp::isExtension()
      *
      * @param DOMNode $node     Node to check.
      * @param string  $_        (unused).
@@ -234,7 +234,7 @@ class AmpTest extends TestCase
      * Test the check for whether a document is an AMP Story.
      *
      * @dataProvider dataIsAmpStory
-     * @covers       Amp::isAmpStory()
+     * @covers       \AmpProject\Amp::isAmpStory()
      *
      * @param Document $document Document to get check for an AMP Story.
      * @param bool     $expected Expected result.
@@ -268,7 +268,7 @@ class AmpTest extends TestCase
      * Test the check whether a given node is an AMP template.
      *
      * @dataProvider dataIsTemplate
-     * @covers       Amp::isTemplate()
+     * @covers       \AmpProject\Amp::isTemplate()
      *
      * @param DOMNode $node     Node to check.
      * @param bool    $expected Expected boolean result.
@@ -332,7 +332,7 @@ class AmpTest extends TestCase
      * Test the check whether a given node is an AMP iframe.
      *
      * @dataProvider dataIsAmpIframe
-     * @covers       Amp::isAmpIframe()
+     * @covers       \AmpProject\Amp::isAmpIframe()
      *
      * @param DOMNode $node     Node to check.
      * @param bool    $expected Expected boolean result.

--- a/tests/CssLengthTest.php
+++ b/tests/CssLengthTest.php
@@ -9,7 +9,7 @@ use AmpProject\Tests\TestCase;
  *
  * @todo   This is only a stub and basic smoke test, more tests need to be added here, as the plugin didn't have any.
  *
- * @covers CssLength
+ * @covers \AmpProject\CssLength
  * @package ampproject/amp-toolbox
  */
 class CssLengthTest extends TestCase
@@ -18,9 +18,9 @@ class CssLengthTest extends TestCase
     /**
      * Test instantiating empty CssLength.
      *
-     * @covers CssLength::__construct()
-     * @covers CssLength::isValid()
-     * @covers CssLength::isDefined()
+     * @covers \AmpProject\CssLength::__construct()
+     * @covers \AmpProject\CssLength::isValid()
+     * @covers \AmpProject\CssLength::isDefined()
      */
     public function testEmptyCssLengthIsValidButNotDefined()
     {

--- a/tests/DevModeTest.php
+++ b/tests/DevModeTest.php
@@ -22,7 +22,10 @@ class DevModeTest extends TestCase
         ];
     }
 
-    /** @dataProvider dataIsActiveForDocument */
+    /**
+     * @dataProvider dataIsActiveForDocument
+     * @covers \AmpProject\DevMode::isActiveForDocument()
+     */
     public function testIsActiveForDocument($html, $expected)
     {
         $document = Document::fromHtml($html);
@@ -44,7 +47,10 @@ class DevModeTest extends TestCase
         return $testData;
     }
 
-    /** @dataProvider dataHasExemptionForNode */
+    /**
+     * @dataProvider dataHasExemptionForNode
+     * @covers \AmpProject\DevMode::hasExemptionForNode()
+     */
     public function testHasExemptionForNode($document, $expected)
     {
         $node = $document->xpath->query('//*[@id="node_to_test"]')->item(0);
@@ -61,7 +67,10 @@ class DevModeTest extends TestCase
         ];
     }
 
-    /** @dataProvider dataIsExemptFromValidation */
+    /**
+     * @dataProvider dataIsExemptFromValidation
+     * @covers \AmpProject\DevMode::isExemptFromValidation()
+     */
     public function testIsExemptFromValidation($html, $expected)
     {
         $document = Document::fromHtml($html);

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -6,17 +6,20 @@ use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;
+use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
 use DOMNode;
 
 /**
  * Tests for AmpProject\Dom\Document.
  *
- * @covers Document
+ * @covers \AmpProject\Dom\Document
  * @package ampproject/amp-toolbox
  */
 class DocumentTest extends TestCase
 {
+    use MarkupComparison;
+
     /**
      * Data for AmpProject\Dom\Document test.
      *
@@ -400,8 +403,8 @@ class DocumentTest extends TestCase
      * @param string $expected Expected target content.
      *
      * @dataProvider dataDomDocument
-     * @covers       Document::loadHTML()
-     * @covers       Document::saveHTML()
+     * @covers       \AmpProject\Dom\Document::loadHTML()
+     * @covers       \AmpProject\Dom\Document::saveHTML()
      */
     public function testDomDocument($charset, $source, $expected)
     {
@@ -410,28 +413,9 @@ class DocumentTest extends TestCase
     }
 
     /**
-     * Assert markup is equal.
-     *
-     * @param string $expected Expected markup.
-     * @param string $actual   Actual markup.
-     */
-    public function assertEqualMarkup($expected, $actual)
-    {
-        $actual   = preg_replace('/\s+/', ' ', $actual);
-        $expected = preg_replace('/\s+/', ' ', $expected);
-        $actual   = preg_replace('/(?<=>)\s+(?=<)/', '', trim($actual));
-        $expected = preg_replace('/(?<=>)\s+(?=<)/', '', trim($expected));
-
-        $this->assertEquals(
-            array_filter(preg_split('#(<!--.*?-->|<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE)),
-            array_filter(preg_split('#(<!--.*?-->|<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE))
-        );
-    }
-
-    /**
      * Test convertAmpBindAttributes.
      *
-     * @covers Document::convertAmpBindAttributes()
+     * @covers \AmpProject\Dom\Document::convertAmpBindAttributes()
      */
     public function testAmpBindConversion()
     {
@@ -467,8 +451,8 @@ class DocumentTest extends TestCase
     /**
      * Test handling noscript elements in the head.
      *
-     * @covers Document::maybeReplaceNoscriptElements()
-     * @covers Document::maybeRestoreNoscriptElements()
+     * @covers \AmpProject\Dom\Document::maybeReplaceNoscriptElements()
+     * @covers \AmpProject\Dom\Document::maybeRestoreNoscriptElements()
      */
     public function testHeadNoscriptElementHandling()
     {
@@ -551,7 +535,7 @@ class DocumentTest extends TestCase
     /**
      * Test that HEAD and BODY elements are always present.
      *
-     * @covers Document::normalizeDocumentStructure()
+     * @covers \AmpProject\Dom\Document::normalizeDocumentStructure()
      */
     public function testEnsuringHeadBody()
     {
@@ -592,7 +576,7 @@ class DocumentTest extends TestCase
     /**
      * Test that invalid head nodes are moved to body.
      *
-     * @covers Document::moveInvalidHeadNodesToBody()
+     * @covers \AmpProject\Dom\Document::moveInvalidHeadNodesToBody()
      */
     public function testInvalidHeadNodes()
     {
@@ -669,7 +653,7 @@ class DocumentTest extends TestCase
      * Test isValidHeadNode().
      *
      * @dataProvider getHeadNodeData
-     * @covers       Document::isValidHeadNode()
+     * @covers       \AmpProject\Dom\Document::isValidHeadNode()
      *
      * @param Document $dom   DOM document to use.
      * @param DOMNode  $node  Node.
@@ -683,8 +667,7 @@ class DocumentTest extends TestCase
     /**
      * Test that the $html property fetches the right element.
      *
-     * @covers Document::__get()
-     * @covers Document::$html
+     * @covers \AmpProject\Dom\Document::__get()
      */
     public function testHtmlProperty()
     {
@@ -696,8 +679,7 @@ class DocumentTest extends TestCase
     /**
      * Test that the $head property fetches the right element.
      *
-     * @covers Document::__get()
-     * @covers Document::$head
+     * @covers \AmpProject\Dom\Document::__get()
      */
     public function testHeadProperty()
     {
@@ -709,8 +691,7 @@ class DocumentTest extends TestCase
     /**
      * Test that the $body property fetches the right element.
      *
-     * @covers Document::__get()
-     * @covers Document::$body
+     * @covers \AmpProject\Dom\Document::__get()
      */
     public function testBodyProperty()
     {
@@ -722,8 +703,7 @@ class DocumentTest extends TestCase
     /**
      * Test that the $ampElements property fetches the right elements.
      *
-     * @covers Document::__get()
-     * @covers Document::$ampElements
+     * @covers \AmpProject\Dom\Document::__get()
      */
     public function testAmpElementsProperty()
     {
@@ -772,6 +752,7 @@ class DocumentTest extends TestCase
      * Test that AMP dev mode on the root DOM element is initially set.
      *
      * @dataProvider getInitialAmpDevModeData
+     * @covers \AmpProject\Dom\Document::hasInitialAmpDevMode()
      *
      * @param Document $document          Document.
      * @param boolean  $hasInitialDevMode Whether $document should have dev mode initially or not.
@@ -847,7 +828,7 @@ class DocumentTest extends TestCase
      * Test Document::getElementId().
      *
      * @dataProvider getGetElementIdData
-     * @covers Document::getElementId()
+     * @covers \AmpProject\Dom\Document::getElementId()
      *
      * @param array $checks Checks to perform. Each check is an array containing an element, a prefix and an expected ID.
      */
@@ -868,7 +849,7 @@ class DocumentTest extends TestCase
     /**
      * Test whether existing element IDs are taken into account, even if the index counter is off.
      *
-     * @covers Document::getElementId()
+     * @covers \AmpProject\Dom\Document::getElementId()
      */
     public function testGetElementIdOnPreexistingIds()
     {
@@ -929,6 +910,8 @@ class DocumentTest extends TestCase
 
     /**
      * Test the Document::getRemainingCssSpace() method.
+     *
+     * @covers \AmpProject\Dom\Document::getRemainingCustomCssSpace()
      */
     public function testGetRemainingCssSpace()
     {
@@ -951,6 +934,8 @@ class DocumentTest extends TestCase
 
     /**
      * Test the Document::addAmpCustomStyle() method without byte limit.
+     *
+     * @covers \AmpProject\Dom\Document::addAmpCustomStyle()
      */
     public function testAddAmpCustomStyleWithoutLimit()
     {
@@ -974,6 +959,8 @@ class DocumentTest extends TestCase
 
     /**
      * Test the Document::addAmpCustomStyle() method with byte limit.
+     *
+     * @covers \AmpProject\Dom\Document::addAmpCustomStyle()
      */
     public function testAddAmpCustomStyleWithLimit()
     {

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -11,7 +11,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Dom\Element.
  *
- * @covers Element
+ * @covers \AmpProject\Dom\Element
  * @package ampproject/amp-toolbox
  */
 class ElementTest extends TestCase
@@ -39,6 +39,7 @@ class ElementTest extends TestCase
      * Test the byte count property.
      *
      * @dataProvider dataByteCounts
+     * @covers \AmpProject\Dom\Element::__get()
      *
      * @param string $html     HTML to test against.
      * @param int    $expected Expected number of bytes of inline styles.
@@ -53,6 +54,8 @@ class ElementTest extends TestCase
 
     /**
      * Test adding inline styles without CSS byte count limit.
+     *
+     * @covers \AmpProject\Dom\Element::addInlineStyle()
      */
     public function testAddInlineStyleWithoutLimit()
     {
@@ -84,6 +87,8 @@ class ElementTest extends TestCase
 
     /**
      * Test adding inline styles with CSS byte count limit.
+     *
+     * @covers \AmpProject\Dom\Element::addInlineStyle()
      */
     public function testAddInlineStyleWithLimit()
     {

--- a/tests/Optimizer/ConfigurationTest.php
+++ b/tests/Optimizer/ConfigurationTest.php
@@ -9,6 +9,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Test the configuration storage and validation.
  *
+ * @covers \AmpProject\Optimizer\Configuration
  * @package ampproject/amp-toolbox
  */
 final class ConfigurationTest extends TestCase

--- a/tests/Optimizer/CssRuleTest.php
+++ b/tests/Optimizer/CssRuleTest.php
@@ -7,7 +7,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Optimizer\CssRule.
  *
- * @covers  CssRule
+ * @covers  \AmpProject\Optimizer\CssRule
  * @package ampproject/amp-toolbox
  */
 class CssRuleTest extends TestCase
@@ -60,9 +60,9 @@ class CssRuleTest extends TestCase
      *
      * @dataProvider dataCssRuleOutput
      *
-     * @covers CssRule::__construct()
-     * @covers CssRule::applyID()
-     * @covers CssRule::getCss()
+     * @covers \AmpProject\Optimizer\CssRule::__construct()
+     * @covers \AmpProject\Optimizer\CssRule::applyID()
+     * @covers \AmpProject\Optimizer\CssRule::getCss()
      */
     public function testCssRuleOutput($selectors, $properties, $expected)
     {
@@ -139,10 +139,10 @@ class CssRuleTest extends TestCase
      *
      * @dataProvider dataCssRuleMerging
      *
-     * @covers CssRule::__construct()
-     * @covers CssRule::withMediaQuery()
-     * @covers CssRule::canBeMerged()
-     * @covers CssRule::mergeWith()
+     * @covers \AmpProject\Optimizer\CssRule::__construct()
+     * @covers \AmpProject\Optimizer\CssRule::withMediaQuery()
+     * @covers \AmpProject\Optimizer\CssRule::canBeMerged()
+     * @covers \AmpProject\Optimizer\CssRule::mergeWith()
      */
     public function testCssRulesCanBeMerged($ruleAValues, $ruleBValues, $expectedCanBeMerged, $expectedMergedRuleValues = [])
     {

--- a/tests/Optimizer/CssRulesTest.php
+++ b/tests/Optimizer/CssRulesTest.php
@@ -7,18 +7,25 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Optimizer\CssRules.
  *
- * @covers  CssRules
+ * @covers  \AmpProject\Optimizer\CssRules
  * @package ampproject/amp-toolbox
  */
 class CssRulesTest extends TestCase
 {
 
+    /**
+     * @covers \AmpProject\Optimizer\CssRules::getCss()
+     */
     public function testEmptyCollection()
     {
         $cssRules = new CssRules();
         $this->assertEquals('', $cssRules->getCss());
     }
 
+    /**
+     * @covers \AmpProject\Optimizer\CssRules::add()
+     * @covers \AmpProject\Optimizer\CssRules::getCss()
+     */
     public function testSingleRule()
     {
         $cssRules = (new CssRules())
@@ -26,6 +33,10 @@ class CssRulesTest extends TestCase
         $this->assertEquals('h1{color:red}', $cssRules->getCss());
     }
 
+    /**
+     * @covers \AmpProject\Optimizer\CssRules::add()
+     * @covers \AmpProject\Optimizer\CssRules::getCss()
+     */
     public function testMultipleRules()
     {
         $cssRules = (new CssRules())
@@ -35,6 +46,10 @@ class CssRulesTest extends TestCase
         $this->assertEquals('h1{color:red}h2{color:green}h3{color:blue}', $cssRules->getCss());
     }
 
+    /**
+     * @covers \AmpProject\Optimizer\CssRules::add()
+     * @covers \AmpProject\Optimizer\CssRules::getCss()
+     */
     public function testMultipleRulesWithOverlap()
     {
         $cssRules = (new CssRules())
@@ -46,6 +61,10 @@ class CssRulesTest extends TestCase
         $this->assertEquals('h1,h3,h5{color:red}h2,h4{color:green}', $cssRules->getCss());
     }
 
+    /**
+     * @covers \AmpProject\Optimizer\CssRules::add()
+     * @covers \AmpProject\Optimizer\CssRules::getCss()
+     */
     public function testNamedConstructor()
     {
         $cssRules = CssRules::fromCssRuleArray(

--- a/tests/Optimizer/ErrorCollectionTest.php
+++ b/tests/Optimizer/ErrorCollectionTest.php
@@ -9,6 +9,7 @@ use ReflectionClass;
 /**
  * Test the error collection container.
  *
+ * @covers \AmpProject\Optimizer\ErrorCollection
  * @package ampproject/amp-toolbox
  */
 final class ErrorCollectionTest extends TestCase

--- a/tests/Optimizer/ImageDimensionsTest.php
+++ b/tests/Optimizer/ImageDimensionsTest.php
@@ -12,7 +12,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Optimizer\ImageDimensions.
  *
- * @covers  ImageDimensions
+ * @covers  \AmpProject\Optimizer\ImageDimensions
  * @package ampproject/amp-toolbox
  */
 class ImageDimensionsTest extends TestCase

--- a/tests/Optimizer/TransformationEngineTest.php
+++ b/tests/Optimizer/TransformationEngineTest.php
@@ -14,6 +14,7 @@ use ReflectionException;
 /**
  * Test the transformation engine as a whole.
  *
+ * @covers \AmpProject\Optimizer\TransformationEngine
  * @package ampproject/amp-toolbox
  */
 final class TransformationEngineTest extends TestCase
@@ -68,7 +69,7 @@ final class TransformationEngineTest extends TestCase
      * All conversion details will be the same as with optimizeHtml, so there's no point
      * in testing everything twice.
      *
-     * @covers TransformationEngine::optimizeDom()
+     * @covers       \AmpProject\Optimizer\TransformationEngine::optimizeDom()
      */
     public function testOptimizeDom()
     {

--- a/tests/Optimizer/Transformer/AmpBoilerplateTest.php
+++ b/tests/Optimizer/Transformer/AmpBoilerplateTest.php
@@ -13,6 +13,7 @@ use AmpProject\Tests\TestMarkup;
 /**
  * Test the AmpBoilerplate transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\AmpBoilerplate
  * @package ampproject/amp-toolbox
  */
 final class AmpBoilerplateTest extends TestCase

--- a/tests/Optimizer/Transformer/AmpRuntimeCssTest.php
+++ b/tests/Optimizer/Transformer/AmpRuntimeCssTest.php
@@ -13,6 +13,7 @@ use AmpProject\RemoteRequest\StubbedRemoteGetRequest;
 /**
  * Test the AmpRuntimeCss transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\AmpRuntimeCss
  * @package ampproject/amp-toolbox
  */
 final class AmpRuntimeCssTest extends TestCase

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -14,6 +14,7 @@ use AmpProject\Tests\TestMarkup;
 /**
  * Test the PreloadHeroImage transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\PreloadHeroImage
  * @package ampproject/amp-toolbox
  */
 final class PreloadHeroImageTest extends TestCase

--- a/tests/Optimizer/Transformer/ReorderHeadTest.php
+++ b/tests/Optimizer/Transformer/ReorderHeadTest.php
@@ -13,6 +13,7 @@ use AmpProject\Tests\TestMarkup;
 /**
  * Test the ReorderHead transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\ReorderHead
  * @package ampproject/amp-toolbox
  */
 final class ReorderHeadTest extends TestCase

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -14,6 +14,7 @@ use AmpProject\Tests\TestMarkup;
 /**
  * Test the ServerSideRendering transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\ServerSideRendering
  * @package ampproject/amp-toolbox
  */
 final class ServerSideRenderingTest extends TestCase

--- a/tests/Optimizer/Transformer/TransformedIdentifierTest.php
+++ b/tests/Optimizer/Transformer/TransformedIdentifierTest.php
@@ -12,6 +12,7 @@ use AmpProject\Tests\TestMarkup;
 /**
  * Test the TransformedIdentifier transformer.
  *
+ * @covers \AmpProject\Optimizer\Transformer\TransformedIdentifier
  * @package ampproject/amp-toolbox
  */
 final class TransformedIdentifierTest extends TestCase

--- a/tests/RuntimeVersionTest.php
+++ b/tests/RuntimeVersionTest.php
@@ -8,7 +8,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\RuntimeVersion.
  *
- * @covers  RuntimeVersion
+ * @covers  \AmpProject\RuntimeVersion
  * @package ampproject/amp-toolbox
  */
 class RuntimeVersionTest extends TestCase
@@ -40,7 +40,7 @@ class RuntimeVersionTest extends TestCase
     /**
      * Test whether the release version is returned by default.
      *
-     * @covers RuntimeVersion::currentVersion()
+     * @covers \AmpProject\RuntimeVersion::currentVersion()
      */
     public function testItReturnsReleaseVersionByDefault()
     {
@@ -51,7 +51,7 @@ class RuntimeVersionTest extends TestCase
     /**
      * Test whether the canary version can be requested via an option.
      *
-     * @covers RuntimeVersion::currentVersion()
+     * @covers \AmpProject\RuntimeVersion::currentVersion()
      */
     public function testItReturnsCanaryVersionViaOption()
     {

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -7,7 +7,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Url.
  *
- * @covers  Url
+ * @covers  \AmpProject\Url
  * @package ampproject/amp-toolbox
  */
 class UrlTest extends TestCase
@@ -26,7 +26,10 @@ class UrlTest extends TestCase
         ];
     }
 
-    /** @dataProvider dataIsValidNonDataUrl */
+    /**
+     * @dataProvider dataIsValidNonDataUrl
+     * @covers \AmpProject\Url::isValidNonDataUrl()
+     */
     public function testIsValidNonDataUrl($src, $expected)
     {
         $this->assertEquals($expected, Url::isValidNonDataUrl($src));


### PR DESCRIPTION
When trying to do a mutation test run, I notifced that a lot of the `@covers` annotations are wrong.

This fixes that.