### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Improve diff output for PHP files.
+*.php              diff=php
+
+# Mark generated files so diffs are hidden by default.
+/resources/**/*    linguist-generated=true
+/tests/spec/**/*   linguist-generated=true
+
+# Exclude build & test files from dist archives.
+/.github           export-ignore
+/bin               export-ignore
+/tests             export-ignore
+/.phpcs.xml.dist   export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,9 @@
 /.github           export-ignore
 /bin               export-ignore
 /tests             export-ignore
+/.editorconfig     export-ignore
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
 /.phpcs.xml.dist   export-ignore
 /phpstan.neon.dist export-ignore
 /phpunit.xml       export-ignore


### PR DESCRIPTION
The `.gitattributes` file being added by the following PR provides these features:
- Uses PHP-specific diff algorithm for PHP files
- Mark files in `resources` and in `tests/spec` as being generated (so they are hidden by default in diffs)
- Exclude these files/folders from dist archives:
	- `.github/`
	- `bin/`
	- `tests/`
	- `.editorconfig`
	- `.gitattributes`
	- `.gitignore`
	- `.phpcs.xml.dist`
	- `phpstan.neon.dist`
	- `phpunit.xml`

Fixes #47