### PR TITLE
Sync latest spec test suite - 2020-02-04

### DIFF
--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -648,8 +648,8 @@ final class ServerSideRendering implements Transformer
             Attribute::SRC,
             sprintf(
                 'data:image/svg+xml;base64,%s',
-                base64_encode("<svg height='{$height->getNumeral()}' width='{$width->getNumeral()}' "
-                              . "xmlns='http://www.w3.org/2000/svg' version='1.1'/>")
+                base64_encode("<svg height=\"{$height->getNumeral()}\" width=\"{$width->getNumeral()}\" "
+                              . "xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"/>")
             )
         );
 

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -36,7 +36,6 @@ final class SpecTest extends TestCase
         'ServerSideRendering - converts_sizes_attribute_to_css'                => 'see https://github.com/ampproject/amp-toolbox/issues/819',
         'ServerSideRendering - boilerplate_not_removed_when_amp-story_present' => 'Node.js on stories produces partial SSR whereas PHP leaves the original story intact',
         'ServerSideRendering - transforms_layout_intrinsic'                    => 'see https://github.com/ampproject/amp-toolbox/issues/844',
-        'ServerSideRendering - transforms_layout_responsive'                   => 'see https://github.com/ampproject/amp-toolbox/pull/1135',
 
         'PreloadHeroImage - max-hero-image-count-param' => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
         'PreloadHeroImage - disable_via_param'          => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -35,7 +35,6 @@ final class SpecTest extends TestCase
 
         'ServerSideRendering - converts_sizes_attribute_to_css'                => 'see https://github.com/ampproject/amp-toolbox/issues/819',
         'ServerSideRendering - boilerplate_not_removed_when_amp-story_present' => 'Node.js on stories produces partial SSR whereas PHP leaves the original story intact',
-        'ServerSideRendering - transforms_layout_intrinsic'                    => 'see https://github.com/ampproject/amp-toolbox/issues/844',
 
         'PreloadHeroImage - max-hero-image-count-param' => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
         'PreloadHeroImage - disable_via_param'          => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',

--- a/tests/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
+++ b/tests/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/expected_output.html
@@ -9,10 +9,10 @@
   <!-- Auto adds responsive attribute if height, width and sizes -->
   <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive">
     <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
-    <!-- Auto adds responsive attribute if height, width and heights -->
-    <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
-      <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
-    </amp-ad>
+  </amp-ad>
+  <!-- Auto adds responsive attribute if height, width and heights -->
+  <amp-ad class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" type="taboola" data-block-on-consent="_till_responded" width="300" height="250" data-publisher="..." data-mode="thumbnails-a-amp" data-placement="Mobile Below Article Thumbnails AMP" data-article="auto" data-target_type="mix" layout="responsive" i-amphtml-layout="responsive" id="i-amp-0">
+    <i-amphtml-sizer style="display:block;padding-top:83.3333%"></i-amphtml-sizer>
   </amp-ad>
 </body>
 </html>

--- a/tests/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/input.html
+++ b/tests/spec/transformers/valid/ServerSideRendering/transforms_layout_responsive/input.html
@@ -20,6 +20,7 @@
       data-article=auto
       data-target_type=mix
     >
+    </amp-ad>
     <!-- Auto adds responsive attribute if height, width and heights -->
     <amp-ad
       class=""
@@ -34,6 +35,6 @@
       data-article=auto
       data-target_type=mix
     >
-</amp-ad>
+    </amp-ad>
   </body>
 </html>


### PR DESCRIPTION
This PR updates to the latest spec test suite and removes two ignore rules.

It also changes the markup generated for base64-SVGs to use double quotes instead of single quotes so it is consistent with the NodeJS optimizer.