### PR TITLE
Add support for a data-hero-candidate attribute

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -103,5 +103,6 @@ interface Attribute
     const REL_PRERENDER    = 'prerender';
     const REL_STYLESHEET   = 'stylesheet';
 
-    const DATA_HERO = 'data-hero';
+    const DATA_HERO           = 'data-hero';
+    const DATA_HERO_CANDIDATE = 'data-hero-candidate';
 }

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -215,13 +215,15 @@ final class PreloadHeroImage implements Transformer
                     $heroImageCandidates[] = $heroImageCandidate;
                 } elseif (count($heroImageFallbacks) < self::DATA_HERO_MAX) {
                     $heroImageFallback = $this->detectPossibleHeroImageFallbacks($node);
-                    if ($heroImageFallback) {
+                    if (
+                        $heroImageFallback &&
                         // Ensure we don't flag the same image twice. This can happen for placeholder images, which are
                         // flagged on their own and as their parent's placeholder.
-                        if (
+                        (
                             ! $previousHeroImageFallback
                             || $heroImageFallback->getAmpImg() !== $previousHeroImageFallback->getAmpImg()
-                        ) {
+                        )
+                    ) {
                             $heroImageFallbacks[]      = $heroImageFallback;
                             $previousHeroImageFallback = $heroImageFallback;
                         }

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -215,18 +215,18 @@ final class PreloadHeroImage implements Transformer
                     $heroImageCandidates[] = $heroImageCandidate;
                 } elseif (count($heroImageFallbacks) < self::DATA_HERO_MAX) {
                     $heroImageFallback = $this->detectPossibleHeroImageFallbacks($node);
+
+                    // Ensure we don't flag the same image twice. This can happen for placeholder images, which are
+                    // flagged on their own and as their parent's placeholder.
                     if (
-                        $heroImageFallback &&
-                        // Ensure we don't flag the same image twice. This can happen for placeholder images, which are
-                        // flagged on their own and as their parent's placeholder.
-                        (
+                        $heroImageFallback
+                        && (
                             ! $previousHeroImageFallback
                             || $heroImageFallback->getAmpImg() !== $previousHeroImageFallback->getAmpImg()
                         )
                     ) {
-                            $heroImageFallbacks[]      = $heroImageFallback;
-                            $previousHeroImageFallback = $heroImageFallback;
-                        }
+                        $heroImageFallbacks[]      = $heroImageFallback;
+                        $previousHeroImageFallback = $heroImageFallback;
                     }
                 }
             }

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -194,9 +194,11 @@ final class PreloadHeroImage implements Transformer
      */
     private function findHeroImages(Document $document)
     {
-        $heroImageCandidate = null;
-        $heroImages         = [];
-        $node               = $document->body;
+        $heroImages                = [];
+        $heroImageCandidates       = [];
+        $heroImageFallbacks        = [];
+        $previousHeroImageFallback = null;
+        $node                      = $document->body;
 
         while ($node !== null) {
             if (! $node instanceof Element) {
@@ -204,14 +206,29 @@ final class PreloadHeroImage implements Transformer
                 continue;
             }
 
-            $heroImage = $this->detectImageWithDataHero($node);
+            $heroImage = $this->detectImageWithAttribute($node, Attribute::DATA_HERO);
             if ($heroImage) {
                 $heroImages[] = $heroImage;
+            } elseif (count($heroImageCandidates) < self::DATA_HERO_MAX) {
+                $heroImageCandidate = $this->detectImageWithAttribute($node, Attribute::DATA_HERO_CANDIDATE);
+                if ($heroImageCandidate) {
+                    $heroImageCandidates[] = $heroImageCandidate;
+                } elseif (count($heroImageFallbacks) < self::DATA_HERO_MAX) {
+                    $heroImageFallback = $this->detectPossibleHeroImageFallbacks($node);
+                    if ($heroImageFallback) {
+                        // Ensure we don't flag the same image twice. This can happen for placeholder images, which are
+                        // flagged on their own and as their parent's placeholder.
+                        if (
+                            ! $previousHeroImageFallback
+                            || $heroImageFallback->getAmpImg() !== $previousHeroImageFallback->getAmpImg()
+                        ) {
+                            $heroImageFallbacks[]      = $heroImageFallback;
+                            $previousHeroImageFallback = $heroImageFallback;
+                        }
+                    }
+                }
             }
 
-            if (! $heroImageCandidate && count($heroImages) === 0) {
-                $heroImageCandidate = $this->detectHeroImageCandidate($node);
-            }
             if (Amp::isTemplate($node)) {
                 // Ignore images inside templates.
                 $node = $this->skipNodeAndChildren($node);
@@ -220,29 +237,33 @@ final class PreloadHeroImage implements Transformer
             }
         }
 
-        // Optimize data-hero element if defined.
         if (count($heroImages) > 0) {
             return $heroImages;
         }
 
-        // Fall back to auto-detected hero image if available.
-        if ($heroImageCandidate) {
-            return [$heroImageCandidate];
+        while (count($heroImages) < self::DATA_HERO_MAX && count($heroImageCandidates) > 0) {
+            $heroImages[] = array_shift($heroImageCandidates);
         }
 
-        // No hero images to optimize.
-        return [];
+        if (count($heroImages) < 1 && count($heroImageFallbacks) > 0) {
+            $heroImages[] = array_shift($heroImageFallbacks);
+        }
+
+        return $heroImages;
     }
 
     /**
-     * Detect a hero image with the data-hero attribute.
+     * Detect a hero image with a specific attribute.
      *
-     * @param Element $element Element to detect for.
+     * This is used for detecting an image marked with data-hero or data-hero-candidate
+     *
+     * @param Element $element   Element to detect for.
+     * @param string  $attribute Attribute to look for.
      * @return HeroImage|null Detected hero image, or null if none detected.
      */
-    private function detectImageWithDataHero(Element $element)
+    private function detectImageWithAttribute(Element $element, $attribute)
     {
-        if (!$element->hasAttribute(Attribute::DATA_HERO)) {
+        if (!$element->hasAttribute($attribute)) {
             return null;
         }
 
@@ -278,14 +299,14 @@ final class PreloadHeroImage implements Transformer
     }
 
     /**
-     * Detect a hero image candidate.
+     * Detect a possible hero image fallback.
      *
      * The hero image here can come from one of <amp-img>, <amp-video>, <amp-iframe>, <amp-video-iframe>.
      *
      * @param Element $element Element to detect for.
-     * @return HeroImage|null Detected hero image candidate, or null if none detected.
+     * @return HeroImage|null Detected hero image fallback, or null if none detected.
      */
-    private function detectHeroImageCandidate(Element $element)
+    private function detectPossibleHeroImageFallbacks(Element $element)
     {
         if (
             $element->hasAttribute(Attribute::LAYOUT)
@@ -295,27 +316,27 @@ final class PreloadHeroImage implements Transformer
         }
 
         if ($element->tagName === Extension::IMG || $element->tagName === Tag::IMG) {
-            return $this->detectHeroImageCandidateForAmpImg($element);
+            return $this->detectPossibleHeroImageFallbackForAmpImg($element);
         }
 
-        if ($element->tagName === EXTENSION::VIDEO) {
-            return $this->detectHeroImageCandidateForPosterImage($element);
+        if ($element->tagName === Extension::VIDEO) {
+            return $this->detectPossibleHeroImageFallbackForPosterImage($element);
         }
 
         if ($this->isAmpEmbed($element)) {
-            return $this->detectHeroImageCandidateForPlaceholderImage($element);
+            return $this->detectPossibleHeroImageFallbackForPlaceholderImage($element);
         }
 
         return null;
     }
 
     /**
-     * Detect a hero image candidate from an <amp-img> element.
+     * Detect a possible hero image fallback from an <amp-img> element.
      *
      * @param Element $element Element to detect for.
-     * @return HeroImage|null Detected hero image candidate, or null if none detected.
+     * @return HeroImage|null Detected hero image fallback, or null if none detected.
      */
-    private function detectHeroImageCandidateForAmpImg(Element $element)
+    private function detectPossibleHeroImageFallbackForAmpImg(Element $element)
     {
         $src = $element->getAttribute(Attribute::SRC);
 
@@ -338,12 +359,12 @@ final class PreloadHeroImage implements Transformer
     }
 
     /**
-     * Detect a hero image candidate from a video's poster (= placeholder) image.
+     * Detect a possible hero image fallback from a video's poster (= placeholder) image.
      *
      * @param Element $element Element to detect for.
-     * @return HeroImage|null Detected hero image candidate, or null if none detected.
+     * @return HeroImage|null Detected hero image fallback, or null if none detected.
      */
-    private function detectHeroImageCandidateForPosterImage(Element $element)
+    private function detectPossibleHeroImageFallbackForPosterImage(Element $element)
     {
         $poster = $element->getAttribute(Attribute::POSTER);
 
@@ -365,12 +386,12 @@ final class PreloadHeroImage implements Transformer
     }
 
     /**
-     * Detect a hero image candidate from a placeholder image.
+     * Detect a possible hero image fallback from a placeholder image.
      *
      * @param Element $element Element to detect for.
-     * @return HeroImage|null Detected hero image candidate, or null if none detected.
+     * @return HeroImage|null Detected hero image fallback, or null if none detected.
      */
-    private function detectHeroImageCandidateForPlaceholderImage(Element $element)
+    private function detectPossibleHeroImageFallbackForPlaceholderImage(Element $element)
     {
         // The placeholder will be a child node of the element.
         if (! $element->hasChildNodes()) {

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -205,6 +205,55 @@ final class PreloadHeroImageTest extends TestCase
                     . '</amp-img>'
                 ),
             ],
+
+            'hero image candidates are turned into hero images' => [
+                $input(
+                    '<amp-img data-hero-candidate width="500" height="400" src="/img1.png"></amp-img>'
+                ),
+                $output(
+                    '<amp-img data-hero data-hero-candidate width="500" height="400" src="/img1.png" i-amphtml-ssr>'
+                    . '<img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/img1.png">'
+                    . '</amp-img>'
+                ),
+            ],
+
+            'superfluous candidates are ignored without throwing an error' => [
+                $input(
+                    '<amp-img width="500" height="400" src="/foo.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero1.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero2.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero3.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero4.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero5.png"></amp-img>'
+                ),
+                $output(
+                    '<amp-img width="500" height="400" src="/foo.png"></amp-img>'
+                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero1.png"></amp-img>'
+                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero2.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero2.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero3.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero4.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero5.png"></amp-img>'
+                ),
+            ],
+
+            'hero images trump hero image candidates' => [
+                $input(
+                    '<amp-img width="500" height="400" src="/foo.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero1.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero2.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero3.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero4.png"></amp-img>'
+                    . '<amp-img data-hero width="500" height="400" src="/hero5.png"></amp-img>'
+                ),
+                $output(
+                    '<amp-img width="500" height="400" src="/foo.png"></amp-img>'
+                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero1.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero2.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero2.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero3.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero4.png"></amp-img>'
+                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero5.png"></amp-img>'
+                ),
+            ],
         ];
     }
 

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -247,11 +247,11 @@ final class PreloadHeroImageTest extends TestCase
                 ),
                 $output(
                     '<amp-img width="500" height="400" src="/foo.png"></amp-img>'
-                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero1.png"></amp-img>'
-                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero2.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero2.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero1.png"></amp-img>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/hero2.png"></amp-img>'
                     . '<amp-img data-hero-candidate width="500" height="400" src="/hero3.png"></amp-img>'
                     . '<amp-img data-hero-candidate width="500" height="400" src="/hero4.png"></amp-img>'
-                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/hero5.png"></amp-img>'
+                    . '<amp-img data-hero width="500" height="400" src="/hero5.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero5.png"></amp-img>'
                 ),
             ],
         ];


### PR DESCRIPTION
This PR changes the `PreloadHeroImages` transformer to use the following logic:
1. Use all elements with `data-hero` attribute up to the max of 2 (throw error when past max).
2. If no `data-hero` attribute is found use all elements with `data-hero-candidate` attribute up to the max of 2 (no errors thrown).
3. If neither `data-hero` nor `data-hero-candidate` attribute is found, use first element that qualifies as "hero image fallback".