### PR TITLE
Add automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,18 @@
+name: Automatic Merge
+on:
+  schedule:
+    # Every day at half past midnight: https://crontab.guru/#30_0_*_*_*
+    - cron: 30 0 * * *
+
+jobs:
+  merge:
+    name: Merge Pull Requests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Merge
+        uses: nucleos/auto-merge-action@1
+        env:
+          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: automerge

--- a/.github/workflows/sync-local-fallback-files.yml
+++ b/.github/workflows/sync-local-fallback-files.yml
@@ -2,7 +2,7 @@ name: Sync runtime local fallback files
 on:
   schedule:
     # https://crontab.guru/every-night-at-midnight
-    - cron: "0 0 * * *"
+    - cron: 0 0 * * *
 
 jobs:
   sync-local-fallback-files:
@@ -87,10 +87,10 @@ jobs:
           steps.remote-branch.outputs.exists == 0
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: "sync-local-fallback-files"
-          destination_branch: "main"
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          pr_title: "Sync local fallback files"
-          pr_body: "${{ steps.body.outputs.text }}"
-          pr_reviewer: "schlessera"
-          pr_label: "SSR"
+          source_branch: sync-local-fallback-files
+          destination_branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: Sync local fallback files
+          pr_body: ${{ steps.body.outputs.text }}
+          pr_reviewer: schlessera
+          pr_label: SSR,automerge

--- a/.github/workflows/sync-spec-test-suite.yml
+++ b/.github/workflows/sync-spec-test-suite.yml
@@ -2,7 +2,7 @@ name: Sync spec test suite from NodeJS toolbox
 on:
   schedule:
     # https://crontab.guru/every-night-at-midnight
-    - cron: "0 0 * * *"
+    - cron: 0 0 * * *
 
 jobs:
   sync-spec-test-suite:
@@ -87,10 +87,10 @@ jobs:
           steps.remote-branch.outputs.exists == 0
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: "sync-spec-test-suite"
-          destination_branch: "main"
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          pr_title: "Sync spec test suite"
-          pr_body: "${{ steps.body.outputs.text }}"
-          pr_reviewer: "schlessera"
-          pr_label: "Testing"
+          source_branch: sync-spec-test-suite
+          destination_branch: main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: Sync spec test suite
+          pr_body: ${{ steps.body.outputs.text }}
+          pr_reviewer: schlessera
+          pr_label: Testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: Run tests
-
 on: [push, pull_request]
 
 jobs:
   unit-test:
-    name: "Unit test${{ matrix.coverage && ' (with coverage)' || '' }} / PHP ${{ matrix.php }}"
+    name: Unit test${{ matrix.coverage && ' (with coverage)' || '' }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This avoids running the workflows twice in such a case.
@@ -62,7 +61,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -cF php -f "$PWD/build/logs/clover.xml"
 
   code-style:
-    name: "Code style / PHP ${{ matrix.php }}"
+    name: Code style / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This avoids running the workflows twice in such a case.
@@ -101,7 +100,7 @@ jobs:
         run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
   static-analysis:
-    name: "Static analysis / PHP ${{ matrix.php }}"
+    name: Static analysis / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This avoids running the workflows twice in such a case.


### PR DESCRIPTION
This PR adds a GHA workflow that automatically merges PRs that fulfill the following conditions:
- the PR has the label `automerge`
- the PR has all of its checks passing

This is triggered every day at half past midnight.

The PR also adds this `automerge` label to the PRs that are generated for synchronizing the fallback files.
