### PR TITLE
Fix broken encoding when using document fragments

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -177,8 +177,6 @@ final class Document extends DOMDocument
 
     const HTML_GET_HEAD_OPENING_TAG_PATTERN     = '/(?><!--.*?-->\s*)*<head(?>\s+[^>]*)?>/is';
     const HTML_GET_HEAD_OPENING_TAG_REPLACEMENT = '$0' . self::HTTP_EQUIV_META_TAG;
-    const HTML_GET_BODY_OPENING_TAG_PATTERN     = '/(?><!--.*?-->\s*)*<body(?>\s+[^>]*)?>/is';
-    const HTML_GET_BODY_OPENING_TAG_REPLACEMENT = '<head>' . self::HTTP_EQUIV_META_TAG . '</head>$0';
     const HTML_GET_HTML_OPENING_TAG_PATTERN     = '/(?><!--.*?-->\s*)*<html(?>\s+[^>]*)?>/is';
     const HTML_GET_HTML_OPENING_TAG_REPLACEMENT = '$0<head>' . self::HTTP_EQUIV_META_TAG . '</head>';
     const HTML_GET_HTTP_EQUIV_TAG_PATTERN       = '#<meta http-equiv=([\'"])content-type\1 '
@@ -2072,29 +2070,8 @@ final class Document extends DOMDocument
             $count
         );
 
-        // In case no <head> node was found, we try to prepend it together with the http-equiv to the <body> tag.
-        if ($count < 1) {
-            $html = preg_replace(
-                self::HTML_GET_BODY_OPENING_TAG_PATTERN,
-                self::HTML_GET_BODY_OPENING_TAG_REPLACEMENT,
-                $html,
-                1,
-                $count
-            );
-        }
 
-        // If no <body> was found either, we look for the <html> tag instead.
-        if ($count < 1) {
-            $html = preg_replace(
-                self::HTML_GET_HTML_OPENING_TAG_PATTERN,
-                self::HTML_GET_HTML_OPENING_TAG_REPLACEMENT,
-                $html,
-                1,
-                $count
-            );
-        }
-
-        // If no <html> was found either, we look for the <!doctype> tag instead.
+        // If no <head> was found, we look for the <html> tag instead.
         if ($count < 1) {
             $html = preg_replace(
                 self::HTML_GET_HTML_OPENING_TAG_PATTERN,

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -1190,4 +1190,121 @@ class DocumentTest extends TestCase
         $documentFragment->loadHTMLFragment('<div></div>', '524288');
         $this->assertEquals($expectedOptions, $documentFragment->getOptions());
     }
+
+    /**
+     * Data for document fragment tests.
+     *
+     * @return array Data.
+     */
+    public function dataDocumentFragment()
+    {
+        return [
+            'encoding_without_doctype_without_html_without_head_without_body' => [
+                'utf-8',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_without_html_without_head_with_body' => [
+                'utf-8',
+                '<body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_without_html_with_head_without_body' => [
+                'utf-8',
+                '<head></head><div style="Iñtërnâtiônàlizætiøn"></div>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_without_html_with_head_with_body' => [
+                'utf-8',
+                '<head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_with_html_without_head_without_body' => [
+                'utf-8',
+                '<html><div style="Iñtërnâtiônàlizætiøn"></div></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_with_html_without_head_with_body' => [
+                'utf-8',
+                '<html><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_with_html_with_head_without_body' => [
+                'utf-8',
+                '<html><head></head><div style="Iñtërnâtiônàlizætiøn"></div></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_without_doctype_with_html_with_head_with_body' => [
+                'utf-8',
+                '<html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_without_html_without_head_without_body' => [
+                'utf-8',
+                '<!DOCTYPE html><div style="Iñtërnâtiônàlizætiøn"></div>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_without_html_without_head_with_body' => [
+                'utf-8',
+                '<!DOCTYPE html><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_without_html_with_head_without_body' => [
+                'utf-8',
+                '<!DOCTYPE html><head></head><div style="Iñtërnâtiônàlizætiøn"></div>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_without_html_with_head_with_body' => [
+                'utf-8',
+                '<!DOCTYPE html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_with_html_without_head_without_body' => [
+                'utf-8',
+                '<!DOCTYPE html><html><div style="Iñtërnâtiônàlizætiøn"></div></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_with_html_without_head_with_body' => [
+                'utf-8',
+                '<!DOCTYPE html><html><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_with_html_with_head_without_body' => [
+                'utf-8',
+                '<!DOCTYPE html><html><head></head><div style="Iñtërnâtiônàlizætiøn"></div></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+            'encoding_with_doctype_with_html_with_head_with_body' => [
+                'utf-8',
+                '<!DOCTYPE html><html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
+                '<div style="Iñtërnâtiônàlizætiøn"></div>',
+            ],
+        ];
+    }
+
+    /**
+     * Tests loading and saving a document fragment.
+     *
+     * @param string        $charset          Charset to use.
+     * @param string        $source           Source content.
+     * @param string        $expected         Expected target content.
+     * @param callable|null $fragmentCallback Optional. Callback to use for fetching the fragment node to compare.
+     *                                        Defaults to retrieving the first child node of the body tag.
+     *
+     * @dataProvider dataDocumentFragment
+     * @covers       \AmpProject\Dom\Document::loadHTML()
+     * @covers       \AmpProject\Dom\Document::saveHTML()
+     */
+    public function testDocumentFragment($charset, $source, $expected, $fragmentCallback = null)
+    {
+        if ($fragmentCallback === null) {
+            $fragmentCallback = static function (Document $document) {
+                return $document->body->firstChild;
+            };
+        }
+
+        $document = Document::fromHtmlFragment($source, $charset);
+
+        $this->assertEqualMarkup($expected, $document->saveHTMLFragment($fragmentCallback($document)));
+    }
 }

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -1198,88 +1198,31 @@ class DocumentTest extends TestCase
      */
     public function dataDocumentFragment()
     {
-        return [
-            'encoding_without_doctype_without_html_without_head_without_body' => [
-                'utf-8',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_without_html_without_head_with_body' => [
-                'utf-8',
-                '<body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_without_html_with_head_without_body' => [
-                'utf-8',
-                '<head></head><div style="Iñtërnâtiônàlizætiøn"></div>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_without_html_with_head_with_body' => [
-                'utf-8',
-                '<head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_with_html_without_head_without_body' => [
-                'utf-8',
-                '<html><div style="Iñtërnâtiônàlizætiøn"></div></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_with_html_without_head_with_body' => [
-                'utf-8',
-                '<html><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_with_html_with_head_without_body' => [
-                'utf-8',
-                '<html><head></head><div style="Iñtërnâtiônàlizætiøn"></div></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_without_doctype_with_html_with_head_with_body' => [
-                'utf-8',
-                '<html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_without_html_without_head_without_body' => [
-                'utf-8',
-                '<!DOCTYPE html><div style="Iñtërnâtiônàlizætiøn"></div>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_without_html_without_head_with_body' => [
-                'utf-8',
-                '<!DOCTYPE html><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_without_html_with_head_without_body' => [
-                'utf-8',
-                '<!DOCTYPE html><head></head><div style="Iñtërnâtiônàlizætiøn"></div>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_without_html_with_head_with_body' => [
-                'utf-8',
-                '<!DOCTYPE html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_with_html_without_head_without_body' => [
-                'utf-8',
-                '<!DOCTYPE html><html><div style="Iñtërnâtiônàlizætiøn"></div></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_with_html_without_head_with_body' => [
-                'utf-8',
-                '<!DOCTYPE html><html><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_with_html_with_head_without_body' => [
-                'utf-8',
-                '<!DOCTYPE html><html><head></head><div style="Iñtërnâtiônàlizætiøn"></div></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-            'encoding_with_doctype_with_html_with_head_with_body' => [
-                'utf-8',
-                '<!DOCTYPE html><html><head></head><body><div style="Iñtërnâtiônàlizætiøn"></div></body></html>',
-                '<div style="Iñtërnâtiônàlizætiøn"></div>',
-            ],
-        ];
+        $target = '<div style="Iñtërnâtiônàlizætiøn"></div>';
+
+        foreach ([true, false] as $body) {
+            foreach ([true, false] as $head) {
+                foreach ([true, false] as $html) {
+                    foreach ([true, false] as $doctype) {
+                        $source = $body ? '<body>' . $target . '</body>' : $target;
+                        $case   = $body ? 'with_body' : 'without_body';
+
+                        $source = $head ? '<head></head>' . $source : $source;
+                        $case   = $head ? 'with_head_' . $case : 'without_head_' . $case;
+
+                        $source = $html ? '<html>' . $source . '</html>' : $source;
+                        $case   = $html ? 'with_html_' . $case : 'without_html_' . $case;
+
+                        $source = $doctype ? '<!DOCTYPE html>' . $source : $source;
+                        $case   = $doctype ? 'with_doctype_' . $case : 'without_doctype_' . $case;
+
+                        $cases["fragment_encoding_{$case}"] = ['utf-8', $source, $target];
+                    }
+                }
+            }
+        }
+
+        return $cases;
     }
 
     /**

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -6,6 +6,7 @@ use AmpProject\Dom\Document;
 use AmpProject\Optimizer\Error;
 use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Optimizer\Exception\InvalidHtmlAttribute;
+use AmpProject\Tag;
 use AmpProject\Tests\ErrorComparison;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
@@ -152,8 +153,8 @@ final class ServerSideRenderingTest extends TestCase
                 [
                     Error\CannotRemoveBoilerplate::fromRenderDelayingScript(
                         Document::fromHtmlFragment(
-                            TestMarkup::SCRIPT_AMPSTORY
-                        )->head->firstChild
+                            '<head>' . TestMarkup::SCRIPT_AMPSTORY . '</head>'
+                        )->head->lastChild
                     ),
                 ],
             ],
@@ -164,8 +165,8 @@ final class ServerSideRenderingTest extends TestCase
                 [
                     Error\CannotRemoveBoilerplate::fromRenderDelayingScript(
                         Document::fromHtmlFragment(
-                            TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES
-                        )->head->firstChild
+                            '<head>' . TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES . '</head>'
+                        )->head->lastChild
                     ),
                 ],
             ],


### PR DESCRIPTION
This ensures that the `http-equiv` charset meta tag needed for making the `DOMDocument` work properly with UTF-8 encoding is always added, even when all or parts of the HTML document structure are missing.

The current implementation does multiple regex calls, with the assumption that this optimizes for large documents where a `<head>` tag would normally always be present. So for any full real-world HTML document, only the first regex would ever be used. For actual document fragments, this assumes they would be small anyway, making multiple regex traversals cheap in these cases.

These multiple regex calls could be combined into one, but this would likely make the most common case much worse in terms of performance. Thoughts on that, @westonruter ?

Fixes #28