### PR TITLE
Fix wrongly urlencoded src attributes in mustache templates

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1460,13 +1460,13 @@ final class Document extends DOMDocument
         // Build a tag pattern that consumes whitespace padding.
         $tagPattern = [];
         foreach (array_keys($mustacheTagPlaceholders) as $token) {
-            if ( '{' === $token[0] ) {
-                $tagPattern[] = preg_quote( $token, ':' ) . '\s*';
+            if ('{' === $token[0]) {
+                $tagPattern[] = preg_quote($token, ':') . '\s*';
             } else {
-                $tagPattern[] = '\s*' . preg_quote( $token, ':' );
+                $tagPattern[] = '\s*' . preg_quote($token, ':');
             }
         }
-        $tagPattern = ':' . implode( '|', $tagPattern ) . ':';
+        $tagPattern = ':' . implode('|', $tagPattern) . ':';
 
         foreach ($templates as $template) {
             foreach ($this->xpath->query(self::XPATH_URL_ENCODED_ATTRIBUTES_QUERY, $template) as $attribute) {

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1510,7 +1510,6 @@ final class Document extends DOMDocument
      *
      * @return string[] Mapping of mustache tag token to its placeholder.
      * @see \wpdb::placeholder_escape()
-     *
      */
     private function getMustacheTagPlaceholders()
     {
@@ -1542,6 +1541,8 @@ final class Document extends DOMDocument
      * Get a regular expression that matches all amp-mustache tags while consuming whitespace.
      *
      * Removing whitespace is needed to avoid DOMDocument turning whitespace into entities, like %20 for spaces.
+     *
+     * @return string Regex pattern to match amp-mustache tags with whitespace.
      */
     private function getMustacheTagPattern()
     {

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1471,7 +1471,7 @@ final class Document extends DOMDocument
                     // entities. In the case of a URL value like '/foo/?bar=1&baz=2' the result is a warning for an
                     // unterminated entity reference "baz". When the attribute value is updated via setAttribute() this
                     // same problem does not occur, so that is why the following is used.
-                    $attribute->parentNode->setAttribute($attribute->nodeName, $value);
+                    $attribute->parentNode->setAttribute($attribute->nodeName, str_replace(' ', '', $value));
 
                     $this->mustacheTagsReplaced = true;
                 }

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1458,15 +1458,16 @@ final class Document extends DOMDocument
         $mustacheTagPlaceholders = $this->getMustacheTagPlaceholders();
 
         // Build a tag pattern that consumes whitespace padding.
+        $delimiter  = ':';
         $tagPattern = [];
         foreach (array_keys($mustacheTagPlaceholders) as $token) {
             if ('{' === $token[0]) {
-                $tagPattern[] = preg_quote($token, ':') . '\s*';
+                $tagPattern[] = preg_quote($token, $delimiter) . '\s*';
             } else {
-                $tagPattern[] = '\s*' . preg_quote($token, ':');
+                $tagPattern[] = '\s*' . preg_quote($token, $delimiter);
             }
         }
-        $tagPattern = ':' . implode('|', $tagPattern) . ':';
+        $tagPattern = $delimiter . implode('|', $tagPattern) . $delimiter;
 
         foreach ($templates as $template) {
             foreach ($this->xpath->query(self::XPATH_URL_ENCODED_ATTRIBUTES_QUERY, $template) as $attribute) {

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -400,7 +400,8 @@ class DocumentTest extends TestCase
             ],
             'mustache_url_encoded_attributes_in_template_tags' => [
                 'utf-8',
-                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{    src    }}"></a></form></div></template></body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{		src
+    }}"></a></form></div></template></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
             ],
             'mustache_url_encoded_attributes_in_script_tags' => [

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -401,8 +401,8 @@ class DocumentTest extends TestCase
             'mustache_url_encoded_attributes_in_template_tags' => [
                 'utf-8',
                 '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{		src
-    }}"></a></form></div></template></body></html>',
-                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
+    }}"></a><img src="/test/image with spaces.jpg" /></form></div></template></body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a><img src="/test/image%20with%20spaces.jpg"></form></div></template></body></html>',
             ],
             'mustache_url_encoded_attributes_in_script_tags' => [
                 'utf-8',

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -400,7 +400,7 @@ class DocumentTest extends TestCase
             ],
             'mustache_url_encoded_attributes_in_template_tags' => [
                 'utf-8',
-                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{    src    }}"></a></form></div></template></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><template type="amp-mustache"><div><form action="{{action}}"><a href="{{url}}"><img src="{{src}}"></a></form></div></template></body></html>',
             ],
             'mustache_url_encoded_attributes_in_script_tags' => [


### PR DESCRIPTION
In our tests with the amp-optimizer we found a small bug: Inside `<template>` Elements `src` attributes get url encoded. I've adjusted a testcase to demonstrate the issue.

`<template type="amp-mustache"><img src="{{ src }}" />` becomes `<template type="amp-mustache"><img src="{{%20src%20}}" />`, which breaks mustache. This might happen on accident (e.g. autoformatting) or on purpose (we deliberatly add whitespace to `{{ src }}` for better readability).

While the workaround would be just to remove the whitespace in the source, I'd prefer to fix this in the optimizer.. 
With this PR I strip all whitespaces inside `XPATH_URL_ENCODED_ATTRIBUTES_QUERY` attributes (`src`, `href` and `action`). Not sure if this is correct in all cases; there might be other [pitfalls](https://amp.dev/documentation/components/amp-mustache/#quote-escaping).