### PR TITLE
Prevent loading=lazy attribute from being removed from amp-story-player poster img

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -103,6 +103,7 @@ interface Attribute
     const REL_PRERENDER    = 'prerender';
     const REL_STYLESHEET   = 'stylesheet';
 
-    const DATA_HERO           = 'data-hero';
-    const DATA_HERO_CANDIDATE = 'data-hero-candidate';
+    const DATA_AMP_STORY_PLAYER_POSTER_IMG = 'data-amp-story-player-poster-img';
+    const DATA_HERO                        = 'data-hero';
+    const DATA_HERO_CANDIDATE              = 'data-hero-candidate';
 }

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -488,7 +488,7 @@ final class PreloadHeroImage implements Transformer
 
         $img = $heroImage->getAmpImg();
 
-        if ($img && $img->getAttribute(Attribute::LOADING) === 'lazy') {
+        if ($img && $img->getAttribute(Attribute::LOADING) === 'lazy' && ! $img->hasAttribute('data-amp-story-player-poster-img')) {
             $img->removeAttribute(Attribute::LOADING);
         }
 

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -488,7 +488,11 @@ final class PreloadHeroImage implements Transformer
 
         $img = $heroImage->getAmpImg();
 
-        if ($img && $img->getAttribute(Attribute::LOADING) === 'lazy' && ! $img->hasAttribute('data-amp-story-player-poster-img')) {
+        if (
+            $img && $img->getAttribute(Attribute::LOADING) === 'lazy'
+            &&
+            ! $img->hasAttribute(Attribute::DATA_AMP_STORY_PLAYER_POSTER_IMG)
+        ) {
             $img->removeAttribute(Attribute::LOADING);
         }
 

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -254,6 +254,34 @@ final class PreloadHeroImageTest extends TestCase
                     . '<amp-img data-hero width="500" height="400" src="/hero5.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/hero5.png"></amp-img>'
                 ),
             ],
+
+            'strips lazy-loading attribute' => [
+                $input(
+                    '<amp-img width="500" height="400" src="/img1.png" loading="lazy"></amp-img>'
+                ),
+                $output(
+                    '<amp-img data-hero width="500" height="400" src="/img1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/img1.png"></amp-img>'
+                ),
+            ],
+
+            'keeps lazy-loading attribute for amp-story-player poster images' => [
+                $input(
+                    '<amp-story-player layout="fixed" width="360" height="600">'
+                    . '<a href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp/">'
+                    . '<img src="https://amp.dev/static/samples/img/story_dog2_portrait.jpg" width="360" height="600" loading="lazy" data-amp-story-player-poster-img>'
+                    . 'Stories in AMP - Hello World'
+                    . '</a>'
+                    . '</amp-story-player>'
+                ),
+                $output(
+                    '<amp-story-player layout="fixed" width="360" height="600">'
+                    . '<a href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp/">'
+                    . '<img src="https://amp.dev/static/samples/img/story_dog2_portrait.jpg" width="360" height="600" loading="lazy" data-amp-story-player-poster-img>'
+                    . 'Stories in AMP - Hello World'
+                    . '</a>'
+                    . '</amp-story-player>'
+                ),
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes something that has come up with a spec update in the plugin: https://github.com/ampproject/amp-wp/pull/5998.

For the first time, outside of `noscript`, AMP is allowing `img` in an AMP page, inside of an [`amp-story-player`](https://amp.dev/documentation/components/amp-story-player/):

```html
<amp-story-player layout="fixed" width="360" height="600">
	<a href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp/">
		<img src="https://amp.dev/static/samples/img/story_dog2_portrait.jpg" width="360" height="600" loading="lazy" data-amp-story-player-poster-img>
		Stories in AMP - Hello World
	</a>
</amp-story-player>
```

In order to be valid, the `img` must be a child of a link and have both the `data-amp-story-player-poster-img` attribute and the `loading=lazy` attribute. Unfortunately, the `PreloadHeroImage` is stripping out the `loading=lazy` attribute from the `img` when the image is identified for preloading. As a quick fix for validity, this should be prevented when the `data-amp-story-player-poster-img` attribute is present.