### PR TITLE
Remove hard-coded isTiny() result for intrinsic layout

### DIFF
--- a/src/Optimizer/ImageDimensions.php
+++ b/src/Optimizer/ImageDimensions.php
@@ -194,8 +194,6 @@ final class ImageDimensions
         }
 
         switch ($this->getLayout()) {
-            // For 'intrinsic' layout, the natural dimensions are more important, so assume not tiny for now.
-            case Layout::INTRINSIC:
             // For 'responsive' layout, the image adapts to the container and can grow beyond its dimensions.
             case Layout::RESPONSIVE:
                 return false;

--- a/tests/Optimizer/ImageDimensionsTest.php
+++ b/tests/Optimizer/ImageDimensionsTest.php
@@ -375,7 +375,7 @@ class ImageDimensionsTest extends TestCase
             'zero height with no layout'                => [500, 0, null, null, true],
             'zero width & height with no layout'        => [0, 0, null, null, true],
             'large intrinsic'                           => [500, 500, Layout::INTRINSIC, null, false],
-            'small intrinsic'                           => [50, 50, Layout::INTRINSIC, null, false],
+            'small intrinsic'                           => [50, 50, Layout::INTRINSIC, null, true],
             'large responsive'                          => [500, 500, Layout::RESPONSIVE, null, false],
             'small responsive'                          => [50, 50, Layout::RESPONSIVE, null, false],
             'large fixed height'                        => ['auto', 500, Layout::FIXED_HEIGHT, null, false],

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -38,7 +38,6 @@ final class SpecTest extends TestCase
 
         'PreloadHeroImage - max-hero-image-count-param'    => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
         'PreloadHeroImage - disable_via_param'             => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
-        'PreloadHeroImage - ignores_tiny_images_intrinsic' => 'see https://github.com/ampproject/amp-toolbox/pull/1184',
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -36,8 +36,9 @@ final class SpecTest extends TestCase
         'ServerSideRendering - converts_sizes_attribute_to_css'                => 'see https://github.com/ampproject/amp-toolbox/issues/819',
         'ServerSideRendering - boilerplate_not_removed_when_amp-story_present' => 'Node.js on stories produces partial SSR whereas PHP leaves the original story intact',
 
-        'PreloadHeroImage - max-hero-image-count-param' => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
-        'PreloadHeroImage - disable_via_param'          => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
+        'PreloadHeroImage - max-hero-image-count-param'    => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
+        'PreloadHeroImage - disable_via_param'             => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
+        'PreloadHeroImage - ignores_tiny_images_intrinsic' => 'see https://github.com/ampproject/amp-toolbox/pull/1184',
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';

--- a/tests/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_intrinsic/expected_output.html
+++ b/tests/spec/transformers/valid/OptimizeHeroImages/ignores_tiny_images_intrinsic/expected_output.html
@@ -4,6 +4,6 @@
 </head>
 <body>
   <amp-img width="32" height="32" src="/small.png"></amp-img>
-  <amp-img width="16" height="9" layout="intrinsic" src="/big.png" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/big.png"></amp-img>
+  <amp-img width="16" height="9" layout="intrinsic" src="/big.png"></amp-img>
 </body>
 </html>


### PR DESCRIPTION
There is an error in the `isTiny()` where the width & height are ignored for an `intrinsic` layout. This is not correct, as for the intrinsic layout, the image is shrinking to fit the container, but can only grow up to the maximum of its width and height attributes. So if these are below the `isTiny()` threshold, it should be flagged accordingly.