### PR TITLE
Fix SSR for nested AMP components

### DIFF
--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -292,7 +292,7 @@ final class ServerSideRendering implements Transformer
 
         try {
             /** @var Element $newElement */
-            $newElement = $element->cloneNode(true);
+            $newElement = $element->cloneNode(false);
 
             // Transformed AMP validation requires layout attribute to be set.
             // See https://github.com/ampproject/amp-toolbox/issues/959
@@ -303,6 +303,9 @@ final class ServerSideRendering implements Transformer
             $this->applyLayoutAttributes($newElement, $layout, $width, $height);
             $this->maybeAddSizerInto($document, $newElement, $layout, $width, $height);
             $element->parentNode->replaceChild($newElement, $element);
+            while ($element->firstChild) {
+                $newElement->appendChild($element->removeChild($element->firstChild));
+            }
         } catch (MaxCssByteCountExceeded $exception) {
             $errors->add(
                 Error\CannotPerformServerSideRendering::fromMaxCssByteCountExceededException($exception, $element)

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -85,6 +85,14 @@ final class ServerSideRenderingTest extends TestCase
                 $expectWithoutBoilerplate('<amp-img class="i-amphtml-layout-container" layout="container" i-amphtml-layout="container"></amp-img>'),
             ],
 
+            'nested amp component' => [
+                $input('<amp-layout layout="fill"><amp-img height="300" layout="responsive" src="https://acme.org/image1.png" width="400"></amp-img></amp-layout>'),
+                $expectWithoutBoilerplate(
+                    '<amp-layout class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill" layout="fill"><amp-img height="300" layout="responsive" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive"><i-amphtml-sizer style="display:block;padding-top:75%"></i-amphtml-sizer></amp-img></amp-layout>'
+                ),
+                [],
+            ],
+
             'amp4Email boilerplate removed and layout applied' => [
                 TestMarkup::DOCTYPE . '<html ⚡4email><head>'
                 . TestMarkup::META_CHARSET . TestMarkup::SCRIPT_AMPRUNTIME . TestMarkup::STYLE_AMP_4_EMAIL_BOILERPLATE


### PR DESCRIPTION
I ran across something really strange when looking at the SSR output of an `amp-accordion` which contained an `amp-img`: only the `amp-accordion` was getting transformed. The `amp-img` was not getting modified at all. I determined the issue was that the SSR transformer was doing a deep clone of `amp-accordion` resulting in the un-SSR'ed descendant `amp-img` then being carried through to the final document.

The fix is simply to do a shallow copy and then move the child nodes from the old element to be children of the new element.

This should also be faster or at least use less memory.