### PR TITLE
Fix deduplication of AMP scripts and improve ReorderHead transformer

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -12,6 +12,7 @@
 
 	<!-- Exclude Composer vendor folder -->
 	<exclude-pattern>amp-toolbox/vendor/</exclude-pattern>
+	<exclude-pattern>amp-toolbox-php/vendor/</exclude-pattern>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.6-"/>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -11,8 +11,7 @@
 	<exclude-pattern>resources/*</exclude-pattern>
 
 	<!-- Exclude Composer vendor folder -->
-	<exclude-pattern>amp-toolbox/vendor/</exclude-pattern>
-	<exclude-pattern>amp-toolbox-php/vendor/</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.6-"/>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<exclude-pattern>resources/*</exclude-pattern>
 
 	<!-- Exclude Composer vendor folder -->
-	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>amp-toolbox/vendor/</exclude-pattern>
 
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.6-"/>

--- a/src/Amp.php
+++ b/src/Amp.php
@@ -151,7 +151,9 @@ final class Amp
 
         if (
             substr($src, -6) !== '/v0.js'
+            && substr($src, -7) !== '/v0.mjs'
             && substr($src, -14) !== '/amp4ads-v0.js'
+            && substr($src, -15) !== '/amp4ads-v0.mjs'
         ) {
             return false;
         }

--- a/src/Amp.php
+++ b/src/Amp.php
@@ -150,6 +150,7 @@ final class Amp
         }
 
         if (
+			// @TODO Compare performance against single regex.
             substr($src, -6) !== '/v0.js'
             && substr($src, -7) !== '/v0.mjs'
             && substr($src, -14) !== '/amp4ads-v0.js'

--- a/src/Amp.php
+++ b/src/Amp.php
@@ -150,7 +150,7 @@ final class Amp
         }
 
         if (
-			// @TODO Compare performance against single regex.
+            // @TODO Compare performance against single regex.
             substr($src, -6) !== '/v0.js'
             && substr($src, -7) !== '/v0.mjs'
             && substr($src, -14) !== '/amp4ads-v0.js'

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -63,7 +63,7 @@ final class ReorderHead implements Transformer
     private $noscript                          = null;
     private $others                            = [];
     private $resourceHintLinks                 = [];
-    private $scriptAmpRuntime                  = null;
+    private $scriptAmpRuntime                  = [];
     private $scriptAmpViewer                   = null;
     private $scriptNonRenderDelayingExtensions = [];
     private $scriptRenderDelayingExtensions    = [];
@@ -157,7 +157,7 @@ final class ReorderHead implements Transformer
     private function registerScript(Element $node)
     {
         if (Amp::isRuntimeScript($node)) {
-            $this->scriptAmpRuntime = $node;
+            $this->scriptAmpRuntime[$node->getAttribute('src')] = $node;
             return;
         }
 

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -303,7 +303,7 @@ final class ReorderHead implements Transformer
                 $this->recursiveKeySort($this->$category);
                 array_walk_recursive(
                     $this->$category,
-                    static function (Element $node) use ($document) {
+                    static function (DOMNode $node) use ($document) {
                         $node = $document->importNode($node);
                         $document->head->appendChild($node);
                     }

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -300,6 +300,8 @@ final class ReorderHead implements Transformer
                 $node = $document->importNode($this->$category);
                 $document->head->appendChild($node);
             } elseif (is_array($this->$category)) {
+                // @todo Do recursive sort so that module is always before nomodule?
+                ksort($this->$category);
                 array_walk_recursive(
                     $this->$category,
                     static function ( Element $node ) use ( $document ) {

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -248,6 +248,7 @@ final class ReorderHead implements Transformer
             || $this->containsWord($rel, Attribute::REL_PREFETCH)
             || $this->containsWord($rel, Attribute::REL_DNS_PREFETCH)
             || $this->containsWord($rel, Attribute::REL_PRECONNECT)
+            || $this->containsWord($rel, Attribute::REL_MODULEPRELOAD)
         ) {
             if ($this->isHintForAmp($node)) {
                 $this->ampResourceHints[] = $node;

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -303,7 +303,7 @@ final class ReorderHead implements Transformer
                 $this->recursiveKeySort($this->$category);
                 array_walk_recursive(
                     $this->$category,
-                    static function ( Element $node ) use ( $document ) {
+                    static function (Element $node) use ($document) {
                         $node = $document->importNode($node);
                         $document->head->appendChild($node);
                     }
@@ -317,10 +317,11 @@ final class ReorderHead implements Transformer
      *
      * @param array|mixed $item Item.
      */
-    private function recursiveKeySort( &$item ) {
+    private function recursiveKeySort(&$item)
+    {
         if (is_array($item)) {
             ksort($item);
-            array_walk( $item, [$this, 'recursiveKeySort']);
+            array_walk($item, [$this, 'recursiveKeySort']);
         }
     }
 

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -300,8 +300,7 @@ final class ReorderHead implements Transformer
                 $node = $document->importNode($this->$category);
                 $document->head->appendChild($node);
             } elseif (is_array($this->$category)) {
-                // @todo Do recursive sort so that module is always before nomodule?
-                ksort($this->$category);
+                $this->recursiveKeySort($this->$category);
                 array_walk_recursive(
                     $this->$category,
                     static function ( Element $node ) use ( $document ) {
@@ -310,6 +309,18 @@ final class ReorderHead implements Transformer
                     }
                 );
             }
+        }
+    }
+
+    /**
+     * Sort array keys recursively.
+     *
+     * @param array|mixed $item Item.
+     */
+    private function recursiveKeySort( &$item ) {
+        if (is_array($item)) {
+            ksort($item);
+            array_walk( $item, [$this, 'recursiveKeySort']);
         }
     }
 

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -261,25 +261,6 @@ final class ReorderHead implements Transformer
     }
 
     /**
-     * Get the name of the custom node or template.
-     *
-     * @param Element $node Node to get the name of.
-     * @return string Name of the custom node or template. Empty string if none found.
-     */
-    private function getName(Element $node)
-    {
-        if ($node->hasAttribute(Attribute::CUSTOM_ELEMENT)) {
-            return $node->getAttribute(Attribute::CUSTOM_ELEMENT);
-        }
-
-        if ($node->hasAttribute(Attribute::CUSTOM_TEMPLATE)) {
-            return $node->getAttribute(Attribute::CUSTOM_TEMPLATE);
-        }
-
-        return '';
-    }
-
-    /**
      * Append all registered nodes to the <head> node.
      *
      * @param Document $document Document to append the nodes to.
@@ -331,7 +312,8 @@ final class ReorderHead implements Transformer
         foreach (['scriptRenderDelayingExtensions', 'scriptNonRenderDelayingExtensions'] as $set) {
             $sortedNodes = [];
             foreach ($this->$set as $node) {
-                $sortedNodes[$this->getName($node)] = $node;
+                /** @var Element $node */
+                $sortedNodes[$node->getAttribute('src')] = $node;
             }
             ksort($sortedNodes);
             $this->$set = array_values($sortedNodes);

--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -88,7 +88,7 @@ final class RewriteAmpUrls implements Transformer
     public function transform(Document $document, ErrorCollection $errors)
     {
         $host          = $this->calculateHost();
-        $referenceNode = $this->findReferenceNode($document);
+        $referenceNode = $document->viewport;;
 
         $preloadNodes = array_filter($this->collectPreloadNodes($document, $host));
         foreach ($preloadNodes as $preloadNode) {
@@ -346,30 +346,5 @@ final class RewriteAmpUrls implements Transformer
         $meta->setAttribute(Attribute::CONTENT, $content);
         $firstScript = $document->xpath->query('./script', $document->head)->item(0);
         $document->head->insertBefore($meta, $firstScript);
-    }
-
-    /**
-     * Find the reference node to use for adding elements.
-     *
-     * It fetches the last <link> after the viewport as the reference node, falling back to the viewport if needed.
-     *
-     * @param Document $document Document to find the reference node in.
-     * @return Element|null Reference node to use, or null if none found.
-     */
-    private function findReferenceNode(Document $document)
-    {
-        $referenceNode = $document->viewport;
-
-        while (
-            $referenceNode !== null
-            &&
-            $referenceNode->nextSibling instanceof Element
-            &&
-            $referenceNode->nextSibling->tagName === Tag::LINK
-        ) {
-            $referenceNode = $referenceNode->nextSibling;
-        }
-
-        return $referenceNode;
     }
 }

--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -88,7 +88,7 @@ final class RewriteAmpUrls implements Transformer
     public function transform(Document $document, ErrorCollection $errors)
     {
         $host          = $this->calculateHost();
-        $referenceNode = $document->viewport;;
+        $referenceNode = $document->viewport;
 
         $preloadNodes = array_filter($this->collectPreloadNodes($document, $host));
         foreach ($preloadNodes as $preloadNode) {

--- a/tests/Optimizer/Transformer/ReorderHeadTest.php
+++ b/tests/Optimizer/Transformer/ReorderHeadTest.php
@@ -56,8 +56,8 @@ final class ReorderHeadTest extends TestCase
                 TestMarkup::SCRIPT_AMPEXPERIMENT .
                 // (6) <script> tags for remaining extensions
                 TestMarkup::SCRIPT_AMPAUDIO .
-                TestMarkup::SCRIPT_AMPMRAID .
                 TestMarkup::SCRIPT_AMPMUSTACHE .
+                TestMarkup::SCRIPT_AMPMRAID .
                 // (7) <link> tag for favicons
                 TestMarkup::LINK_FAVICON .
                 // (8) <link> tag for resource hints
@@ -179,7 +179,7 @@ final class ReorderHeadTest extends TestCase
 
                 TestMarkup::DOCTYPE . '<html ⚡><head>' .
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
-                TestMarkup::SCRIPT_AMPRUNTIME . TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES . TestMarkup::SCRIPT_AMPEXPERIMENT .
+                TestMarkup::SCRIPT_AMPRUNTIME . TestMarkup::SCRIPT_AMPEXPERIMENT . TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES .
                 TestMarkup::LINK_FAVICON . TestMarkup::LINK_CANONICAL .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
                 '</head><body></body></html>',

--- a/tests/Optimizer/Transformer/ReorderHeadTest.php
+++ b/tests/Optimizer/Transformer/ReorderHeadTest.php
@@ -56,8 +56,8 @@ final class ReorderHeadTest extends TestCase
                 TestMarkup::SCRIPT_AMPEXPERIMENT .
                 // (6) <script> tags for remaining extensions
                 TestMarkup::SCRIPT_AMPAUDIO .
-                TestMarkup::SCRIPT_AMPMUSTACHE .
                 TestMarkup::SCRIPT_AMPMRAID .
+                TestMarkup::SCRIPT_AMPMUSTACHE .
                 // (7) <link> tag for favicons
                 TestMarkup::LINK_FAVICON .
                 // (8) <link> tag for resource hints
@@ -179,7 +179,7 @@ final class ReorderHeadTest extends TestCase
 
                 TestMarkup::DOCTYPE . '<html ⚡><head>' .
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
-                TestMarkup::SCRIPT_AMPRUNTIME . TestMarkup::SCRIPT_AMPEXPERIMENT . TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES .
+                TestMarkup::SCRIPT_AMPRUNTIME . TestMarkup::SCRIPT_AMPDYNAMIC_CSSCLASSES . TestMarkup::SCRIPT_AMPEXPERIMENT .
                 TestMarkup::LINK_FAVICON . TestMarkup::LINK_CANONICAL .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
                 '</head><body></body></html>',

--- a/tests/Optimizer/Transformer/ReorderHeadTest.php
+++ b/tests/Optimizer/Transformer/ReorderHeadTest.php
@@ -55,8 +55,8 @@ final class ReorderHeadTest extends TestCase
                 // (5) <script> tags that are render delaying
                 TestMarkup::SCRIPT_AMPEXPERIMENT .
                 // (6) <script> tags for remaining extensions
-                TestMarkup::SCRIPT_AMPMRAID .
                 TestMarkup::SCRIPT_AMPAUDIO .
+                TestMarkup::SCRIPT_AMPMRAID .
                 TestMarkup::SCRIPT_AMPMUSTACHE .
                 // (7) <link> tag for favicons
                 TestMarkup::LINK_FAVICON .

--- a/tests/Optimizer/Transformer/RewriteAmpUrlsTest.php
+++ b/tests/Optimizer/Transformer/RewriteAmpUrlsTest.php
@@ -54,8 +54,8 @@ final class RewriteAmpUrlsTest extends TestCase
         $this->assertCount(0, $errors);
         $this->assertSimilarMarkup(
             TestMarkup::DOCTYPE . '<html amp><head>' . TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT
-            . TestMarkup::LINK_CANONICAL . TestMarkup::LINK_GOOGLE_FONT_PRECONNECT
             . '<link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">'
+            . TestMarkup::LINK_CANONICAL . TestMarkup::LINK_GOOGLE_FONT_PRECONNECT
             . '<script async nomodule src="https://cdn.ampproject.org/v0.js"></script>'
             . '<script async crossorigin="anonymous" src="https://cdn.ampproject.org/v0.mjs" type="module"></script>'
             . '</head><body></body></html>',

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
@@ -1,16 +1,17 @@
 <!doctype html>
 <html ⚡>
 <head>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
-  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
+  <script async="" nomodule="" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
+  <script async="" custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
   <link href="https://example.com/favicon.ico" rel="icon">
-  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
 </head>
 <body></body>
 </html>

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
+  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
+  <link href="https://example.com/favicon.ico" rel="icon">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
+  <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
+</head>
+<body></body>
+</html>

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html ⚡>
 <head>
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
@@ -10,7 +11,6 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
   <link href="https://example.com/favicon.ico" rel="icon">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
 </head>
 <body></body>
 </html>

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
@@ -1,17 +1,16 @@
 <!doctype html>
 <html ⚡>
 <head>
-  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
-  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
   <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <script async="" nomodule="" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
-  <script async="" custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
   <link href="https://example.com/favicon.ico" rel="icon">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
 </head>
 <body></body>
 </html>

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/expected_output.html
@@ -5,10 +5,11 @@
   <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
   <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
   <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
-  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
-  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
   <link href="https://example.com/favicon.ico" rel="icon">
   <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
 </head>

--- a/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/input.html
+++ b/tests/spec/transformers/valid/ReorderHeadTransformer/supports_esm/input.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <script async nomodule src="https://cdn.ampproject.org/v0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js" custom-template="amp-mustache"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.mjs" type="module" crossorigin="anonymous"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
+  <script async nomodule src="https://cdn.ampproject.org/v0/amp-experiment-0.1.js" custom-element="amp-experiment"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <script async custom-element="amp-experiment" src="https://cdn.ampproject.org/v0/amp-experiment-0.1.mjs" type="module" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/v0.css">
+  <link href="https://fonts.googleapis.com/css?foobar" rel="stylesheet" type="text/css">
+  <link href="https://example.com/favicon.ico" rel="icon">
+  <link as="script" crossorigin="anonymous" href="https://cdn.ampproject.org/v0.mjs" rel="modulepreload">
+  <link rel="preload" href="https://cdn.ampproject.org/v0.css" as="style">
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
Ports (and depends on) https://github.com/ampproject/amp-toolbox/pull/1192. See https://github.com/ampproject/amp-toolbox/issues/1191. Fixes #125.