### PR TITLE
Only construct preload if it is needed

### DIFF
--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -496,6 +496,12 @@ final class PreloadHeroImage implements Transformer
             $img->removeAttribute(Attribute::LOADING);
         }
 
+        if (empty($heroImage->getMedia())) {
+            // We can only safely preload a hero image if there's a media attribute
+            // as we can't detect whether it's hidden on certain viewport sizes otherwise.
+            return;
+        }
+
         if ($this->hasExistingImagePreload($document, $heroImage->getSrc())) {
             return;
         }
@@ -514,12 +520,6 @@ final class PreloadHeroImage implements Transformer
             if ($img && $img->hasAttribute(Attribute::SIZES)) {
                 $preload->setAttribute(Attribute::IMAGESIZES, $img->getAttribute(Attribute::SIZES));
             }
-        }
-
-        if (empty($heroImage->getMedia())) {
-            // We can only safely preload a hero image if there's a media attribute
-            // as we can't detect whether it's hidden on certain viewport sizes otherwise.
-            return;
         }
 
         $preload->setAttribute(Attribute::MEDIA, $heroImage->getMedia());


### PR DESCRIPTION
I intended to fix #127 now but found out I had already fixed this as part of a different PR.

However, I noticed that the preload was first being constructed unconditionally before deciding whether to attach it to the document or not. This PR now only does the preload construction if it is actually attached to the document.

Fixes #127 