### PR TITLE
Fix tiny image detection inside responsive parent

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -2081,7 +2081,7 @@ final class Document extends DOMDocument
             return false;
         }
 
-        $element->addAttributes($attributes);
+        $element->setAttributes($attributes);
 
         return $element;
     }

--- a/src/Dom/Element.php
+++ b/src/Dom/Element.php
@@ -240,7 +240,7 @@ final class Element extends DOMElement
      *
      * @param string[] $attributes One or more attributes for the node's HTML element.
      */
-    public function addAttributes($attributes)
+    public function setAttributes($attributes)
     {
         foreach ($attributes as $name => $value) {
             try {

--- a/src/Optimizer/ImageDimensions.php
+++ b/src/Optimizer/ImageDimensions.php
@@ -113,6 +113,11 @@ final class ImageDimensions
                 continue;
             }
 
+            // If layout is responsive, consider dimensions to be unbounded.
+            if (Layout::RESPONSIVE === $element->getAttribute(Attribute::LAYOUT)) {
+                return [PHP_INT_MAX, PHP_INT_MAX];
+            }
+
             return [(int)$width, (int)$height];
         }
 

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -393,27 +393,27 @@ class ElementTest extends TestCase
     /**
      * Test adding no attributes to node.
      *
-     * @covers \AmpProject\Dom\Element::addAttributes()
+     * @covers \AmpProject\Dom\Element::setAttributes()
      */
     public function testAddAttributesToNodeForNoAttributes()
     {
         $dom     = Document::fromHtml('<p>Hello World</p>');
         $element = $dom->createElement('b');
-        $element->addAttributes([]);
+        $element->setAttributes([]);
         $this->assertFalse($element->hasAttributes());
     }
 
     /**
      * Test adding attribute with no value to node.
      *
-     * @covers \AmpProject\Dom\Element::addAttributes()
+     * @covers \AmpProject\Dom\Element::setAttributes()
      */
     public function testAddAttributesToNodeForAttributeWithoutValue()
     {
         $dom        = Document::fromHtml('<p>Hello World</p>');
         $element    = $dom->createElement('div');
         $attributes = [ 'placeholder' => '' ];
-        $element->addAttributes($attributes);
+        $element->setAttributes($attributes);
 
         $this->assertTrue($element->hasAttributes());
         $this->checkElementHasAttributes($element, $attributes);
@@ -422,7 +422,7 @@ class ElementTest extends TestCase
     /**
      * Test adding attribute with value to node.
      *
-     * @covers \AmpProject\Dom\Element::addAttributes()
+     * @covers \AmpProject\Dom\Element::setAttributes()
      */
     public function testAddAttributesToNodeForAttributeWithValue()
     {
@@ -432,7 +432,7 @@ class ElementTest extends TestCase
             'class' => 'myClass',
             'id'    => 'myId',
         ];
-        $element->addAttributes($attributes);
+        $element->setAttributes($attributes);
 
         $this->assertTrue($element->hasAttributes());
         $this->checkElementHasAttributes($element, $attributes);

--- a/tests/Optimizer/ImageDimensionsTest.php
+++ b/tests/Optimizer/ImageDimensionsTest.php
@@ -410,28 +410,46 @@ class ImageDimensionsTest extends TestCase
     public function testItCanCheckIfAnImageIsTiny($width, $height, $layout, $threshold, $expected)
     {
         $dom   = new Document();
-        $image = $dom->createElement(Tag::IMG);
+        $attrs = [];
 
         if ($width !== null) {
-            $image->setAttribute(Attribute::WIDTH, $width);
+            $attrs[Attribute::WIDTH] = $width;
         }
 
         if ($height !== null) {
-            $image->setAttribute(Attribute::HEIGHT, $height);
+            $attrs[Attribute::HEIGHT] = $height;
         }
 
         if ($layout !== null) {
-            $image->setAttribute(Attribute::LAYOUT, $layout);
+            $attrs[Attribute::LAYOUT] = $layout;
         }
 
-        $parent = $dom->createElement(Tag::FIGURE);
-        $parent->setAttribute(Attribute::WIDTH, 400);
-        $parent->setAttribute(Attribute::HEIGHT, 200);
-
+        // Check in fixed layout parent.
+        $parent = $dom->createElementWithAttributes(
+            'amp-layout',
+            [
+                Attribute::LAYOUT => Layout::FIXED,
+                Attribute::WIDTH  => 400,
+                Attribute::HEIGHT => 200,
+            ]
+        );
+        $image = $dom->createElementWithAttributes(Tag::IMG, $attrs);
         $parent->appendChild($image);
-
         $imageDimensions = new ImageDimensions($image);
+        $this->assertEquals($expected, $imageDimensions->isTiny($threshold));
 
+        // Check in responsive layout parent.
+        $parent = $dom->createElementWithAttributes(
+            'amp-layout',
+            [
+                Attribute::LAYOUT => Layout::RESPONSIVE,
+                Attribute::WIDTH  => 3,
+                Attribute::HEIGHT => 4,
+            ]
+        );
+        $image = $dom->createElementWithAttributes(Tag::IMG, $attrs);
+        $parent->appendChild($image);
+        $imageDimensions = new ImageDimensions($image);
         $this->assertEquals($expected, $imageDimensions->isTiny($threshold));
     }
 }


### PR DESCRIPTION
I found that when an `amp-img` had a `fill` layout and it was inside of a parent which was responsive (with 16x9 dimensions on an `amp-youtube`), the `isTiny` check was returning true unexpectedly. This updates the `getDimensionsFromParent` logic to return the max integer as the width/height when the element has a responsive layout.

Also renames `Element::addAttributes()` to `Element::setAttributes()` per https://github.com/ampproject/amp-toolbox-php/pull/119#discussion_r607587539.