### PR TITLE
Add autoloader scenario for package as dependency

### DIFF
--- a/bin/amp
+++ b/bin/amp
@@ -8,6 +8,7 @@ if (!class_exists('AmpProject\Cli\AmpExecutable')) {
     $possibleAutoloaderLocations = [
         dirname(__DIR__) . '/vendor/autoload.php',
         dirname(__DIR__) . '/autoload.php',
+        // TODO: This should make use of dirname(__DIR__, 3) once we have a PHP minimum of 7+.
         dirname(dirname(dirname(__DIR__))) . 'autoload.php',
     ];
 

--- a/bin/amp
+++ b/bin/amp
@@ -8,6 +8,7 @@ if (!class_exists('AmpProject\Cli\AmpExecutable')) {
     $possibleAutoloaderLocations = [
         dirname(__DIR__) . '/vendor/autoload.php',
         dirname(__DIR__) . '/autoload.php',
+        dirname(dirname(dirname(__DIR__))) . 'autoload.php',
     ];
 
     foreach ($possibleAutoloaderLocations as $possibleAutoloaderLocation) {


### PR DESCRIPTION
The autoloader is not properly detected by the binary `amp` right now if the package was included as a dependency, where it is located at `$project/vendor/ampproject/amp-toolbox/bin/amp`.

This PR adds the above scenario.