### PR TITLE
Add more dynamic logging behavior

### DIFF
--- a/src/Cli/AmpExecutable.php
+++ b/src/Cli/AmpExecutable.php
@@ -2,6 +2,8 @@
 
 namespace AmpProject\Cli;
 
+use AmpProject\Exception\Cli\InvalidCommand;
+
 /**
  * Executable that assembles all of the commands.
  *
@@ -54,7 +56,18 @@ final class AmpExecutable extends Executable
      */
     protected function main(Options $options)
     {
-        $command = $this->commandInstances[$options->getCommand()];
+        $commandName = $options->getCommand();
+
+        if (empty($commandName)) {
+            echo $this->options->help();
+            exit(1);
+        }
+
+        if (! array_key_exists($commandName, $this->commandInstances)) {
+            throw InvalidCommand::forUnregisteredCommand($commandName);
+        }
+
+        $command = $this->commandInstances[$commandName];
 
         $command->process($options);
     }

--- a/src/Cli/Executable.php
+++ b/src/Cli/Executable.php
@@ -358,9 +358,9 @@ abstract class Executable
      */
     protected function setupLogging()
     {
-        $this->level = $this->options->getOption('loglevel', $this->loglevel);
+        $this->loglevel = $this->options->getOption('loglevel', $this->loglevel);
 
-        if (! in_array($this->level, LogLevel::ORDER)) {
+        if (! in_array($this->loglevel, LogLevel::ORDER)) {
             $this->fatal('Unknown log level');
         }
     }

--- a/src/Cli/Executable.php
+++ b/src/Cli/Executable.php
@@ -47,16 +47,16 @@ abstract class Executable
      *
      * @var array<array>
      */
-    protected $loglevel = [
-        'debug'     => ['', Colors::C_RESET, STDOUT],
-        'info'      => ['ℹ ', Colors::C_CYAN, STDOUT],
-        'notice'    => ['☛ ', Colors::C_CYAN, STDOUT],
-        'success'   => ['✓ ', Colors::C_GREEN, STDOUT],
-        'warning'   => ['⚠ ', Colors::C_BROWN, STDERR],
-        'error'     => ['✗ ', Colors::C_RED, STDERR],
-        'critical'  => ['☠ ', Colors::C_LIGHTRED, STDERR],
-        'alert'     => ['✖ ', Colors::C_LIGHTRED, STDERR],
-        'emergency' => ['✘ ', Colors::C_LIGHTRED, STDERR],
+    protected $loglevels = [
+        LogLevel::DEBUG     => ['', Colors::C_RESET, STDOUT],
+        LogLevel::INFO      => ['ℹ ', Colors::C_CYAN, STDOUT],
+        LogLevel::NOTICE    => ['☛ ', Colors::C_CYAN, STDOUT],
+        LogLevel::SUCCESS   => ['✓ ', Colors::C_GREEN, STDOUT],
+        LogLevel::WARNING   => ['⚠ ', Colors::C_BROWN, STDERR],
+        LogLevel::ERROR     => ['✗ ', Colors::C_RED, STDERR],
+        LogLevel::CRITICAL  => ['☠ ', Colors::C_LIGHTRED, STDERR],
+        LogLevel::ALERT     => ['✖ ', Colors::C_LIGHTRED, STDERR],
+        LogLevel::EMERGENCY => ['✘ ', Colors::C_LIGHTRED, STDERR],
     ];
 
     /**
@@ -64,7 +64,7 @@ abstract class Executable
      *
      * @var string
      */
-    protected $logdefault = 'info';
+    protected $loglevel = 'info';
 
     /**
      * Constructor.
@@ -155,7 +155,7 @@ abstract class Executable
      */
     public function emergency($message, array $context = [])
     {
-        $this->log('emergency', $message, $context);
+        $this->log(LogLevel::EMERGENCY, $message, $context);
     }
 
     /**
@@ -169,7 +169,7 @@ abstract class Executable
      */
     public function alert($message, array $context = [])
     {
-        $this->log('alert', $message, $context);
+        $this->log(LogLevel::ALERT, $message, $context);
     }
 
     /**
@@ -183,7 +183,7 @@ abstract class Executable
      */
     public function critical($message, array $context = [])
     {
-        $this->log('critical', $message, $context);
+        $this->log(LogLevel::CRITICAL, $message, $context);
     }
 
     /**
@@ -195,7 +195,7 @@ abstract class Executable
      */
     public function error($message, array $context = [])
     {
-        $this->log('error', $message, $context);
+        $this->log(LogLevel::ERROR, $message, $context);
     }
 
     /**
@@ -209,7 +209,7 @@ abstract class Executable
      */
     public function warning($message, array $context = [])
     {
-        $this->log('warning', $message, $context);
+        $this->log(LogLevel::WARNING, $message, $context);
     }
 
     /**
@@ -221,7 +221,7 @@ abstract class Executable
      */
     public function success($string, array $context = [])
     {
-        $this->log('success', $string, $context);
+        $this->log(LogLevel::SUCCESS, $string, $context);
     }
 
     /**
@@ -233,7 +233,7 @@ abstract class Executable
      */
     public function notice($message, array $context = [])
     {
-        $this->log('notice', $message, $context);
+        $this->log(LogLevel::NOTICE, $message, $context);
     }
 
     /**
@@ -247,7 +247,7 @@ abstract class Executable
      */
     public function info($message, array $context = [])
     {
-        $this->log('info', $message, $context);
+        $this->log(LogLevel::INFO, $message, $context);
     }
 
     /**
@@ -259,7 +259,7 @@ abstract class Executable
      */
     public function debug($message, array $context = [])
     {
-        $this->log('debug', $message, $context);
+        $this->log(LogLevel::DEBUG, $message, $context);
     }
 
     /**
@@ -272,12 +272,11 @@ abstract class Executable
      */
     public function log($level, $message, array $context = [])
     {
-        // Is this log level wanted?
-        if (! isset($this->loglevel[$level])) {
+        if (! LogLevel::matches($level, $this->options->getOption('loglevel', $this->loglevel))) {
             return;
         }
 
-        list($prefix, $color, $channel) = $this->loglevel[$level];
+        list($prefix, $color, $channel) = $this->loglevels[$level];
 
         if (! $this->colors->isEnabled()) {
             $prefix = '';
@@ -333,7 +332,7 @@ abstract class Executable
         );
         $this->options->registerOption(
             'loglevel',
-            "Minimum level of messages to display. Default is {$this->colors->wrap($this->logdefault, Colors::C_CYAN)}."
+            "Minimum level of messages to display. Default is {$this->colors->wrap($this->loglevel, Colors::C_CYAN)}."
             . ' Valid levels are: debug, info, notice, success, warning, error, critical, alert, emergency.',
             null,
             'level'
@@ -359,17 +358,10 @@ abstract class Executable
      */
     protected function setupLogging()
     {
-        $level = $this->options->getOption('loglevel', $this->logdefault);
+        $this->level = $this->options->getOption('loglevel', $this->loglevel);
 
-        if (! isset($this->loglevel[$level])) {
+        if (! in_array($this->level, LogLevel::ORDER)) {
             $this->fatal('Unknown log level');
-        }
-
-        foreach (array_keys($this->loglevel) as $l) {
-            if ($l == $level) {
-                break;
-            }
-            unset($this->loglevel[$l]);
         }
     }
 

--- a/src/Cli/LogLevel.php
+++ b/src/Cli/LogLevel.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace AmpProject\Cli;
+
+use AmpProject\Exception\AmpCliException;
+use AmpProject\Exception\Cli\InvalidSapi;
+use Exception;
+
+/**
+ * Abstract class with the individual log levels.
+ *
+ * @package ampproject/amp-toolbox
+ */
+abstract class LogLevel
+{
+
+    /**
+     * Detailed debug information.
+     *
+     * @var string
+     */
+    const DEBUG = 'debug';
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @var string
+     */
+    const INFO = 'info';
+
+    /**
+     * Normal but significant events.
+     *
+     * @var string
+     */
+    const NOTICE = 'notice';
+
+    /**
+     * Normal, positive outcome.
+     *
+     * @var string
+     */
+    const SUCCESS = 'success';
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things that are not necessarily wrong.
+     *
+     * @var string
+     */
+    const WARNING = 'warning';
+
+    /**
+     * Runtime errors that do not require immediate action but should typically be logged and monitored.
+     *
+     * @var string
+     */
+    const ERROR = 'error';
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @var string
+     */
+    const CRITICAL = 'critical';
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should trigger the SMS alerts and wake you up.
+     *
+     * @var string
+     */
+    const ALERT = 'alert';
+
+    /**
+     * System is unusable.
+     *
+     * @var string
+     */
+    const EMERGENCY = 'emergency';
+
+    /**
+     * Ordering to use for log levels.
+     *
+     * @var string[]
+     */
+    const ORDER = [
+        self::DEBUG,
+        self::INFO,
+        self::NOTICE,
+        self::SUCCESS,
+        self::WARNING,
+        self::ERROR,
+        self::CRITICAL,
+        self::ALERT,
+        self::EMERGENCY,
+    ];
+
+    /**
+     * Test whether a given log level matches the currently set threshold.
+     *
+     * @param string $logLevel Log level to check.
+     * @param string $threshold Log level threshold to check against.
+     * @return bool Whether the provided log level matches the threshold.
+     */
+    public static function matches($logLevel, $threshold)
+    {
+        return array_search($logLevel, self::ORDER, true) >= array_search($threshold, self::ORDER, true);
+    }
+}

--- a/tests/Cli/AmpExecutableTest.php
+++ b/tests/Cli/AmpExecutableTest.php
@@ -84,7 +84,12 @@ class AmpExecutableTest extends TestCase
                    echo "[{$channel}]<{$color}> {$message}";
                });
 
-        $executable = new AmpExecutable(false, null, $colors);
+        $options = $this->createMock(Options::class);
+        $options->method('getOption')
+                ->with('loglevel')
+                ->willReturn('debug');
+
+        $executable = new AmpExecutable(false, $options, $colors);
 
         $this->expectOutputString("[{$channel}]<{$color}> {$prefix}{$logLevel} message");
         $executable->$logLevel('{level} message', ['level' => $logLevel]);
@@ -110,7 +115,12 @@ class AmpExecutableTest extends TestCase
                    echo "[{$channel}]<{$color}> {$message}";
                });
 
-        $executable = new AmpExecutable(false, null, $colors);
+        $options = $this->createMock(Options::class);
+        $options->method('getOption')
+                ->with('loglevel')
+                ->willReturn('debug');
+
+        $executable = new AmpExecutable(false, $options, $colors);
 
         $this->expectOutputString("[{$channel}]<{$color}> {$logLevel} message");
         $executable->log($logLevel, '{level} message', ['level' => $logLevel]);


### PR DESCRIPTION
The way logging was handled made for all options parsing errors to be dumped as full traces.

This PR changes the logging to be more dynamic, so that traces are only shown when the `--loglevel` is set to `debug`.