### PR TITLE
Include candidate hero images after paragraphs and persist `loading` attribute on `noscript > img` fallback

### DIFF
--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -115,7 +115,7 @@ final class PreloadHeroImage implements Transformer
      *
      * @var string
      */
-    const NOSCRIPT_IMG_XPATH_QUERY = './/noscript/img';
+    const NOSCRIPT_IMG_XPATH_QUERY = './noscript/img';
 
     /**
      * Regular expression pattern to extract the URL from a CSS background-image property.

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -115,7 +115,7 @@ final class PreloadHeroImage implements Transformer
      *
      * @var string
      */
-    const NOSCRIPT_IMG_XPATH_QUERY = './/noscript[ img ]';
+    const NOSCRIPT_IMG_XPATH_QUERY = './/noscript/img';
 
     /**
      * Regular expression pattern to extract the URL from a CSS background-image property.
@@ -568,11 +568,19 @@ final class PreloadHeroImage implements Transformer
         $imgElement->setAttribute(Attribute::CLASS_, self::SSR_IMAGE_CLASS);
         $imgElement->setAttribute(Attribute::DECODING, 'async');
 
-
         // If the image was detected as hero image candidate (and thus lacks an explicit data-hero), mark it as a hero
         // and add loading=lazy to guard against making the page performance even worse by eagerly loading an image
-        // outside the viewport.
-        if (! $this->isMarkedAsHeroImage($element)) {
+        // outside the viewport. But if there is a noscript > img then preserve its original loading attribute.
+        $noscript_img = $document->xpath->query(self::NOSCRIPT_IMG_XPATH_QUERY, $element)->item(0);
+        if ($noscript_img instanceof Element) {
+            // Preserve the original loading attribute from the noscript fallback img.
+            if ($noscript_img->hasAttribute(Attribute::LOADING)) {
+                $imgElement->setAttribute(Attribute::LOADING, $noscript_img->getAttribute(Attribute::LOADING));
+            }
+
+            // Remove any noscript>img when an amp-img is pre-rendered.
+            $noscript_img->parentNode->parentNode->removeChild($noscript_img->parentNode);
+        } elseif (! $this->isMarkedAsHeroImage($element)) {
             $imgElement->setAttribute(Attribute::LOADING, 'lazy');
         }
 
@@ -597,12 +605,6 @@ final class PreloadHeroImage implements Transformer
         $element->appendChild($document->createAttribute(Attribute::I_AMPHTML_SSR));
 
         $element->appendChild($imgElement);
-
-        // Remove any noscript>img when an amp-img is pre-rendered.
-        $noscript = $document->xpath->query(self::NOSCRIPT_IMG_XPATH_QUERY, $element)->item(0);
-        if ($noscript instanceof Element) {
-            $noscript->parentNode->removeChild($noscript);
-        }
     }
 
     /**

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -216,11 +216,11 @@ final class PreloadHeroImage implements Transformer
             $heroImage = $this->detectImageWithAttribute($node, Attribute::DATA_HERO);
             if ($heroImage) {
                 $heroImages[] = $heroImage;
-            } elseif ($seenParagraphCount < 2 && count($heroImageCandidates) < self::DATA_HERO_MAX) {
+            } elseif (count($heroImageCandidates) < self::DATA_HERO_MAX) {
                 $heroImageCandidate = $this->detectImageWithAttribute($node, Attribute::DATA_HERO_CANDIDATE);
                 if ($heroImageCandidate) {
                     $heroImageCandidates[] = $heroImageCandidate;
-                } elseif (count($heroImageFallbacks) < self::DATA_HERO_MAX) {
+                } elseif ($seenParagraphCount < 2 && count($heroImageFallbacks) < self::DATA_HERO_MAX) {
                     $heroImageFallback = $this->detectPossibleHeroImageFallbacks($node);
 
                     // Ensure we don't flag the same image twice. This can happen for placeholder images, which are

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -40,7 +40,6 @@ final class SpecTest extends TestCase
 
         'PreloadHeroImage - max-hero-image-count-param'    => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
         'PreloadHeroImage - disable_via_param'             => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
-        'PreloadHeroImage - amp-iframe_data-hero'          => 'see https://github.com/ampproject/amp-toolbox/pull/1198'
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';
@@ -69,23 +68,23 @@ final class SpecTest extends TestCase
             ],
             'PreloadHeroImage'              => [
                 PreloadHeroImage::class,
-                self::TRANSFORMER_SPEC_PATH . '/valid/OptimizeHeroImages'
+                self::TRANSFORMER_SPEC_PATH . '/valid/OptimizeHeroImages',
             ],
             'ReorderHead'                   => [
                 ReorderHead::class,
-                self::TRANSFORMER_SPEC_PATH . '/valid/ReorderHeadTransformer'
+                self::TRANSFORMER_SPEC_PATH . '/valid/ReorderHeadTransformer',
             ],
             'RewriteAmpUrls'                => [
                 RewriteAmpUrls::class,
-                self::TRANSFORMER_SPEC_PATH . '/valid/RewriteAmpUrls'
+                self::TRANSFORMER_SPEC_PATH . '/valid/RewriteAmpUrls',
             ],
             'RewriteAmpUrls (experimental)' => [
                 RewriteAmpUrls::class,
-                self::TRANSFORMER_SPEC_PATH . '/experimental/RewriteAmpUrls'
+                self::TRANSFORMER_SPEC_PATH . '/experimental/RewriteAmpUrls',
             ],
             'ServerSideRendering'           => [
                 ServerSideRendering::class,
-                self::TRANSFORMER_SPEC_PATH . '/valid/ServerSideRendering'
+                self::TRANSFORMER_SPEC_PATH . '/valid/ServerSideRendering',
             ],
         ];
 

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -234,6 +234,21 @@ final class PreloadHeroImageTest extends TestCase
                 ),
             ],
 
+            'hero image candidates after paragraphs are turned into hero images' => [
+                $input(
+                    '<p>First Paragraph</p>'
+                    . '<p>Second Paragraph</p>'
+                    . '<amp-img data-hero-candidate width="500" height="400" src="/img1.png"></amp-img>'
+                ),
+                $output(
+                    '<p>First Paragraph</p>'
+                    . '<p>Second Paragraph</p>'
+                    . '<amp-img data-hero data-hero-candidate width="500" height="400" src="/img1.png" i-amphtml-ssr>'
+                    . '<img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/img1.png">'
+                    . '</amp-img>'
+                ),
+            ],
+
             'superfluous candidates are ignored without throwing an error' => [
                 $input(
                     '<amp-img width="500" height="400" src="/foo.png"></amp-img>'

--- a/tests/Optimizer/Transformer/PreloadHeroImageTest.php
+++ b/tests/Optimizer/Transformer/PreloadHeroImageTest.php
@@ -287,12 +287,30 @@ final class PreloadHeroImageTest extends TestCase
                 ),
             ],
 
-            'strips lazy-loading attribute' => [
+            'adds lazy-loading attribute on auto-detected hero images' => [
                 $input(
-                    '<amp-img width="500" height="400" src="/img1.png" loading="lazy"></amp-img>'
+                    '<amp-img width="500" height="400" src="/img1.png"></amp-img>'
                 ),
                 $output(
                     '<amp-img data-hero width="500" height="400" src="/img1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/img1.png"></amp-img>'
+                ),
+            ],
+
+            'preserves loading attribute from noscript fallback img on prerendered image' => [
+                $input(
+                    '<amp-img width="500" height="400" src="/img1.png"><noscript><img src="/img1.png" width="500" height="400" loading="eager"></noscript></amp-img>'
+                ),
+                $output(
+                    '<amp-img data-hero width="500" height="400" src="/img1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="eager" src="/img1.png"></amp-img>'
+                ),
+            ],
+
+            'omits loading attribute on prerendered image when noscript fallback img lacks it' => [
+                $input(
+                    '<amp-img width="500" height="400" src="/img1.png"><noscript><img src="/img1.png" width="500" height="400"></noscript></amp-img>'
+                ),
+                $output(
+                    '<amp-img data-hero width="500" height="400" src="/img1.png" i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/img1.png"></amp-img>'
                 ),
             ],
 

--- a/tests/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
+++ b/tests/spec/transformers/valid/OptimizeHeroImages/amp-iframe_data-hero/expected_output.html
@@ -7,7 +7,7 @@
     <amp-img placeholder layout="fill" src="no-hero.jpg"></amp-img>
   </amp-iframe>
   <amp-iframe data-hero src="/hero" layout="responsive" width="320" height="900">
-    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="hero.jpg"></amp-img>
+    <amp-img placeholder layout="fill" src="hero.jpg" i-amphtml-ssr data-hero><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="hero.jpg"></amp-img>
   </amp-iframe>
 </body>
 </html>

--- a/tests/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/expected_output.html
+++ b/tests/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/expected_output.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/img1.png" data-hero i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" loading="lazy" src="/img1.png"></amp-img>
+  <amp-img width="500" height="400" src="/img2.png" data-hero i-amphtml-ssr><img class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async" src="/img2.png"></amp-img>
+</body>
+</html>

--- a/tests/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/input.html
+++ b/tests/spec/transformers/valid/OptimizeHeroImages/amp-img_with_noscript_fallbacks/input.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <amp-img width="500" height="400" src="/img1.png" data-hero><noscript><img src="/img1.png" width="500" height="400" loading="lazy"></noscript></amp-img>
+  <amp-img width="500" height="400" src="/img2.png" data-hero><noscript><img src="/img2.png" width="500" height="400"></noscript></amp-img>
+</body>
+</html>


### PR DESCRIPTION
* Honor hero image candidate (with `data-hero-candidate`) even when they occur after multiple paragraphs. This fixes an issue I saw in Twenty Twenty-One where there multiple paragraphs in the header, preventing any images in the entry content from being made heros via the AMP plugin's `DetermineHeroImages` transformer.
* When prerendering a hero image, persist the `loading` attribute from its `noscript > img` fallback. If the fallback `img` lacks a `loading` attribute (as in the case of the Custom Logo in WordPress), omit it from the SSR'ed `img` as well. If the fallback `img` has `loading=lazy`, then add it to the SSR'ed image as well (as is done for content images in WP). Fixes #147. Done in https://github.com/ampproject/amp-toolbox/pull/1198 via https://github.com/ampproject/amp-toolbox/pull/1198/commits/16a1a855d7108dfcc401f079991a33eb196d49ab.