### PR TITLE
Make Configuration extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ AMP Optimizer is a library for doing server-side optimization to AMP markup by a
 
 ### Conceptual Overview
 
-<!-- TODO: Once the repositories have been extracted out, all PHP references should link to the corresponding files in the repositories -->
-
 The AMP Optimizer is a [`AmpProject\Optimizer\TransformationEngine`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/TransformationEngine.php) object that sets up a pipeline of consecutive [`AmpProject\Optimizer\Transformer`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/Transformer.php) objects. The engine takes unoptimized input in the form of either a HTML markup string or an [`AmpProject\Dom\Document`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Dom/Document.php) object and turns it into an optimized HTML markup string.
 
 During the process, errors might occur that make parts of the optimization impossible. These are collected within an [`AmpProject\Optimizer\ErrorCollection`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/ErrorCollection.php) object that you can then iterate over to find out more and provide feedback as needed.
@@ -152,12 +150,13 @@ Note that this only lets you check whether an error "category" popped up. It can
 
 You can inject a configuration object into the [`AmpProject\Optimizer\TransformationEngine`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/TransformationEngine.php) to override the default configuration.
 
-The main [`AmpProject\Optimizer\Configuration`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/Configuration.php) object will provide the list of transformers to use, as well as give access to child objects it stores that are Transformer-specific configuration objects.
+The [`AmpProject\Optimizer\Configuration`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/Configuration.php) interface and its default implementation [`AmpProject\Optimizer\DefaultConfiguration`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/DefaultConfiguration.php) will provide the list of transformers to use, as well as give access to child objects they store that are Transformer-specific configuration objects.
 
 To override the list of transformers to use, you can provide an array containing the `AmpProject\Optimizer\Configuration::KEY_TRANSFORMERS` key.
 
 ```php
 use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 use AmpProject\Optimizer\Transformer;
 
@@ -170,7 +169,7 @@ $configurationData = [
 ];
 
 $transformationEngine = new TransformationEngine(
-	new Configuration($configurationData)
+	new DefaultConfiguration($configurationData)
 );
 ```
 
@@ -182,6 +181,7 @@ In the following example, we configure the [`AmpProject\Optimizer\Transformer\Am
 
 ```php
 use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 use AmpProject\Optimizer\Transformer;
 
@@ -192,7 +192,7 @@ $configurationData = [
 ];
 
 $transformationEngine = new TransformationEngine(
-	new Configuration($configurationData)
+	new DefaultConfiguration($configurationData)
 );
 ```
 
@@ -215,6 +215,7 @@ To make this transformer then known to the transformation engine, you add it to 
 
 ```php
 use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 use MyProject\MyCustomTransformer;
 
@@ -228,7 +229,7 @@ $configurationData = [
 ];
 
 $transformationEngine = new TransformationEngine(
-	new Configuration($configurationData)
+	new DefaultConfiguration($configurationData)
 );
 ```
 
@@ -242,6 +243,7 @@ In the following example, we add a new `MyProject\MyCustomTransformer` transform
 
 ```php
 use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 use MyProject\MyCustomTransformer;
 use MyProject\MyCustomTransformerConfiguration;
@@ -258,7 +260,7 @@ $configurationData = [
 	],
 ];
 
-$configuration = new Configuration($configurationData);
+$configuration = new DefaultConfiguration($configurationData);
 
 $configuration->registerConfigurationClass(
 	MyCustomTransformer::class,
@@ -389,11 +391,11 @@ final class MyCustomTransformer implements Transformer
 The implementation to use for fulfilling requests made via the [`AmpProject\RemoteGetRequest`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/RemoteGetRequest.php) interface can be injected into the [`AmpProject\Optimizer\TransformationEngine`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/Optimizer/TransformationEngine.php) via its second, optional argument:
 
 ```php
-use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 
 $transformationEngine = new TransformationEngine(
-	new Configuration(),
+	new DefaultConfiguration(),
 
 	// A custom implementation that lets you control how remote requests are handled.
 	new MyCustomRemoteGetRequestImplementation()
@@ -414,7 +416,7 @@ There are other implementations already provided that can be useful:
 The following code shows an example of how to use a remote request via cURL while falling back to files stored on the disk when an external request fails (probably due to network issues).
 
 ```php
-use AmpProject\Optimizer\Configuration;
+use AmpProject\Optimizer\DefaultConfiguration;
 use AmpProject\Optimizer\TransformationEngine;
 use AmpProject\RemoteRequest\CurlRemoteGetRequest;
 use AmpProject\RemoteRequest\FallbackRemoteGetRequest;
@@ -429,7 +431,7 @@ $remoteRequest = new FallbackRemoteGetRequest(
 	new FilesystemRemoteGetRequest(self::FALLBACK_MAPPING) // ... fall back to shipped files.
 );
 
-$transformationEngine = new TransformationEngine(new Configuration(), $remoteRequest);
+$transformationEngine = new TransformationEngine(new DefaultConfiguration(), $remoteRequest);
 ```
 
 To build your own transport, you'll need to implement the [`AmpProject\RemoteGetRequest`](https://github.com/ampproject/amp-toolbox-php/blob/main/src/RemoteGetRequest.php) interface. For a more involved example of a custom transport or for integrating with your stack of choice, see the two implementations provided by the `Amp for WordPress` WordPress plugin:

--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -2,12 +2,6 @@
 
 namespace AmpProject\Optimizer;
 
-use AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration;
-use AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration;
-use AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration;
-use AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration;
-use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
-use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
 use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
 use AmpProject\Optimizer\Transformer\AmpBoilerplate;
 use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
@@ -18,11 +12,11 @@ use AmpProject\Optimizer\Transformer\ServerSideRendering;
 use AmpProject\Optimizer\Transformer\TransformedIdentifier;
 
 /**
- * Configuration object that validates and stores configuration settings.
+ * Interface for a configuration object that validates and stores configuration settings.
  *
  * @package ampproject/amp-toolbox
  */
-final class Configuration
+interface Configuration
 {
 
     /**
@@ -57,102 +51,12 @@ final class Configuration
     ];
 
     /**
-     * Associative array of already validated configuration settings.
-     *
-     * @var array
-     */
-    private $configuration;
-
-    /**
-     * Associative array mapping the transformer classes to their configuration classes.
-     *
-     * This can be extended by third-parties via:
-     *
-     * @see registerConfigurationClass()
-     *
-     * @var array
-     */
-    private $transformerConfigurationClasses = [
-        AmpRuntimeCss::class         => AmpRuntimeCssConfiguration::class,
-        PreloadHeroImage::class      => PreloadHeroImageConfiguration::class,
-        RewriteAmpUrls::class        => RewriteAmpUrlsConfiguration::class,
-        TransformedIdentifier::class => TransformedIdentifierConfiguration::class,
-    ];
-
-    /**
-     * Instantiate a Configuration object.
-     *
-     * @param array $configurationData Optional. Associative array of configuration data to use. This will be merged
-     *                                 with the default configuration and take precedence.
-     */
-    public function __construct($configurationData = [])
-    {
-        $this->configuration = array_merge(
-            self::DEFAULTS,
-            $this->validateConfigurationKeys($configurationData)
-        );
-    }
-
-    /**
      * Register a new configuration class to use for a given transformer.
      *
      * @param string $transformerClass   FQCN of the transformer to register a configuration class for.
      * @param string $configurationClass FQCN of the configuration to use.
      */
-    public function registerConfigurationClass($transformerClass, $configurationClass)
-    {
-        $this->transformerConfigurationClasses[$transformerClass] = $configurationClass;
-    }
-
-    /**
-     * Validate an array of configuration settings.
-     *
-     * @param array $configurationData Associative array of configuration data to validate.
-     * @return array Associative array of validated configuration data.
-     */
-    private function validateConfigurationKeys($configurationData)
-    {
-        foreach ($configurationData as $key => $value) {
-            $configurationData[$key] = $this->validate($key, $value);
-        }
-
-        return $configurationData;
-    }
-
-    /**
-     * Validate an individual configuration setting.
-     *
-     * @param string $key   Key of the configuration setting.
-     * @param mixed  $value Value of the configuration setting.
-     * @return mixed Validated value for the provided configuration setting.
-     * @throws InvalidConfigurationValue If the configuration value could not be validated.
-     */
-    private function validate($key, $value)
-    {
-        switch ($key) {
-            case self::KEY_TRANSFORMERS:
-                if (! is_array($value)) {
-                    throw InvalidConfigurationValue::forInvalidValueType(
-                        self::KEY_TRANSFORMERS,
-                        'array',
-                        gettype($value)
-                    );
-                }
-
-                foreach ($value as $index => $entry) {
-                    if (! is_string($entry)) {
-                        throw InvalidConfigurationValue::forInvalidSubValueType(
-                            self::KEY_TRANSFORMERS,
-                            $index,
-                            'string',
-                            gettype($entry)
-                        );
-                    }
-                }
-        }
-
-        return $value;
-    }
+    public function registerConfigurationClass($transformerClass, $configurationClass);
 
     /**
      * Check whether the configuration has a given setting.
@@ -160,10 +64,7 @@ final class Configuration
      * @param string $key Configuration key to look for.
      * @return bool Whether the requested configuration key was found or not.
      */
-    public function has($key)
-    {
-        return array_key_exists($key, $this->configuration);
-    }
+    public function has($key);
 
     /**
      * Get the value for a given key from the configuration.
@@ -172,14 +73,7 @@ final class Configuration
      * @return mixed Configuration value for the requested key.
      * @throws UnknownConfigurationKey If the key was not found.
      */
-    public function get($key)
-    {
-        if (! array_key_exists($key, $this->configuration)) {
-            throw UnknownConfigurationKey::fromKey($key);
-        }
-
-        return $this->configuration[$key];
-    }
+    public function get($key);
 
     /**
      * Get the transformer-specific configuration for the requested transformer.
@@ -187,15 +81,5 @@ final class Configuration
      * @param string $transformer FQCN of the transformer to get the configuration for.
      * @return TransformerConfiguration Transformer-specific configuration.
      */
-    public function getTransformerConfiguration($transformer)
-    {
-        if (! array_key_exists($transformer, $this->transformerConfigurationClasses)) {
-            throw UnknownConfigurationClass::fromTransformerClass($transformer);
-        }
-
-        $configuration      = $this->has($transformer) ? $this->get($transformer) : [];
-        $configurationClass = $this->transformerConfigurationClasses[$transformer];
-
-        return new $configurationClass($configuration);
-    }
+    public function getTransformerConfiguration($transformer);
 }

--- a/src/Optimizer/DefaultConfiguration.php
+++ b/src/Optimizer/DefaultConfiguration.php
@@ -54,7 +54,7 @@ class DefaultConfiguration implements Configuration
     public function __construct($configurationData = [])
     {
         $this->configuration = array_merge(
-            Configuration::DEFAULTS,
+            static::DEFAULTS,
             $this->validateConfigurationKeys($configurationData)
         );
     }

--- a/src/Optimizer/DefaultConfiguration.php
+++ b/src/Optimizer/DefaultConfiguration.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace AmpProject\Optimizer;
+
+use AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration;
+use AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration;
+use AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration;
+use AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration;
+use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
+use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
+use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
+use AmpProject\Optimizer\Transformer\PreloadHeroImage;
+use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
+use AmpProject\Optimizer\Transformer\TransformedIdentifier;
+
+/**
+ * Configuration object that validates and stores configuration settings.
+ *
+ * @package ampproject/amp-toolbox
+ */
+class DefaultConfiguration implements Configuration
+{
+
+    /**
+     * Associative array of already validated configuration settings.
+     *
+     * @var array
+     */
+    protected $configuration;
+
+    /**
+     * Associative array mapping the transformer classes to their configuration classes.
+     *
+     * This can be extended by third-parties via:
+     *
+     * @see registerConfigurationClass()
+     *
+     * @var array
+     */
+    protected $transformerConfigurationClasses = [
+        AmpRuntimeCss::class         => AmpRuntimeCssConfiguration::class,
+        PreloadHeroImage::class      => PreloadHeroImageConfiguration::class,
+        RewriteAmpUrls::class        => RewriteAmpUrlsConfiguration::class,
+        TransformedIdentifier::class => TransformedIdentifierConfiguration::class,
+    ];
+
+    /**
+     * Instantiate a Configuration object.
+     *
+     * @param array $configurationData Optional. Associative array of configuration data to use. This will be merged
+     *                                 with the default configuration and take precedence.
+     */
+    public function __construct($configurationData = [])
+    {
+        $this->configuration = array_merge(
+            Configuration::DEFAULTS,
+            $this->validateConfigurationKeys($configurationData)
+        );
+    }
+
+    /**
+     * Register a new configuration class to use for a given transformer.
+     *
+     * @param string $transformerClass   FQCN of the transformer to register a configuration class for.
+     * @param string $configurationClass FQCN of the configuration to use.
+     */
+    public function registerConfigurationClass($transformerClass, $configurationClass)
+    {
+        $this->transformerConfigurationClasses[$transformerClass] = $configurationClass;
+    }
+
+    /**
+     * Validate an array of configuration settings.
+     *
+     * @param array $configurationData Associative array of configuration data to validate.
+     * @return array Associative array of validated configuration data.
+     */
+    protected function validateConfigurationKeys($configurationData)
+    {
+        foreach ($configurationData as $key => $value) {
+            $configurationData[$key] = $this->validate($key, $value);
+        }
+
+        return $configurationData;
+    }
+
+    /**
+     * Validate an individual configuration setting.
+     *
+     * @param string $key   Key of the configuration setting.
+     * @param mixed  $value Value of the configuration setting.
+     * @return mixed Validated value for the provided configuration setting.
+     * @throws InvalidConfigurationValue If the configuration value could not be validated.
+     */
+    protected function validate($key, $value)
+    {
+        switch ($key) {
+            case Configuration::KEY_TRANSFORMERS:
+                if (! is_array($value)) {
+                    throw InvalidConfigurationValue::forInvalidValueType(
+                        Configuration::KEY_TRANSFORMERS,
+                        'array',
+                        gettype($value)
+                    );
+                }
+
+                foreach ($value as $index => $entry) {
+                    if (! is_string($entry)) {
+                        throw InvalidConfigurationValue::forInvalidSubValueType(
+                            Configuration::KEY_TRANSFORMERS,
+                            $index,
+                            'string',
+                            gettype($entry)
+                        );
+                    }
+                }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check whether the configuration has a given setting.
+     *
+     * @param string $key Configuration key to look for.
+     * @return bool Whether the requested configuration key was found or not.
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->configuration);
+    }
+
+    /**
+     * Get the value for a given key from the configuration.
+     *
+     * @param string $key Configuration key to get the value for.
+     * @return mixed Configuration value for the requested key.
+     * @throws UnknownConfigurationKey If the key was not found.
+     */
+    public function get($key)
+    {
+        if (! array_key_exists($key, $this->configuration)) {
+            throw UnknownConfigurationKey::fromKey($key);
+        }
+
+        return $this->configuration[$key];
+    }
+
+    /**
+     * Get the transformer-specific configuration for the requested transformer.
+     *
+     * @param string $transformer FQCN of the transformer to get the configuration for.
+     * @return TransformerConfiguration Transformer-specific configuration.
+     */
+    public function getTransformerConfiguration($transformer)
+    {
+        if (! array_key_exists($transformer, $this->transformerConfigurationClasses)) {
+            throw UnknownConfigurationClass::fromTransformerClass($transformer);
+        }
+
+        $configuration      = $this->has($transformer) ? $this->get($transformer) : [];
+        $configurationClass = $this->transformerConfigurationClasses[$transformer];
+
+        return new $configurationClass($configuration);
+    }
+}

--- a/src/Optimizer/TransformationEngine.php
+++ b/src/Optimizer/TransformationEngine.php
@@ -46,7 +46,7 @@ final class TransformationEngine
      */
     public function __construct(Configuration $configuration = null, RemoteGetRequest $remoteRequest = null)
     {
-        $this->configuration = isset($configuration) ? $configuration : new Configuration();
+        $this->configuration = isset($configuration) ? $configuration : new DefaultConfiguration();
         $this->remoteRequest = isset($remoteRequest) ? $remoteRequest : new CurlRemoteGetRequest();
 
         $this->initializeTransformers();

--- a/tests/Optimizer/DefaultConfigurationTest.php
+++ b/tests/Optimizer/DefaultConfigurationTest.php
@@ -9,21 +9,21 @@ use AmpProject\Tests\TestCase;
 /**
  * Test the configuration storage and validation.
  *
- * @covers \AmpProject\Optimizer\Configuration
+ * @covers \AmpProject\Optimizer\DefaultConfiguration
  * @package ampproject/amp-toolbox
  */
-final class ConfigurationTest extends TestCase
+final class DefaultConfigurationTest extends TestCase
 {
 
     /**
      * Test whether we can retrieve the default configuration.
      *
-     * @covers \AmpProject\Optimizer\Configuration::has()
-     * @covers \AmpProject\Optimizer\Configuration::get()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::has()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::get()
      */
     public function testDefaultConfiguration()
     {
-        $configuration = new Configuration();
+        $configuration = new DefaultConfiguration();
         $this->assertTrue($configuration->has(Configuration::KEY_TRANSFORMERS));
         $this->assertFalse($configuration->has('unknown_key'));
         $this->assertEquals(Configuration::DEFAULT_TRANSFORMERS, $configuration->get(Configuration::KEY_TRANSFORMERS));
@@ -32,12 +32,12 @@ final class ConfigurationTest extends TestCase
     /**
      * Test whether we can add to the default configuration.
      *
-     * @covers \AmpProject\Optimizer\Configuration::has()
-     * @covers \AmpProject\Optimizer\Configuration::get()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::has()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::get()
      */
     public function testUserProvidedConfigurationCanAddKeys()
     {
-        $configuration = new Configuration(['custom_key' => 'custom_value']);
+        $configuration = new DefaultConfiguration(['custom_key' => 'custom_value']);
         $this->assertTrue($configuration->has(Configuration::KEY_TRANSFORMERS));
         $this->assertTrue($configuration->has('custom_key'));
         $this->assertEquals(Configuration::DEFAULT_TRANSFORMERS, $configuration->get(Configuration::KEY_TRANSFORMERS));
@@ -47,12 +47,12 @@ final class ConfigurationTest extends TestCase
     /**
      * Test whether we can override the default configuration.
      *
-     * @covers \AmpProject\Optimizer\Configuration::has()
-     * @covers \AmpProject\Optimizer\Configuration::get()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::has()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::get()
      */
     public function testUserProvidedConfigurationCanOverrideKeys()
     {
-        $configuration = new Configuration([Configuration::KEY_TRANSFORMERS => ['my_transformer']]);
+        $configuration = new DefaultConfiguration([Configuration::KEY_TRANSFORMERS => ['my_transformer']]);
         $this->assertTrue($configuration->has(Configuration::KEY_TRANSFORMERS));
         $this->assertEquals(['my_transformer'], $configuration->get(Configuration::KEY_TRANSFORMERS));
     }
@@ -60,11 +60,11 @@ final class ConfigurationTest extends TestCase
     /**
      * Test whether unknown keys throw an exception.
      *
-     * @covers \AmpProject\Optimizer\Configuration::get()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::get()
      */
     public function testUnknownKeyThrowsException()
     {
-        $configuration = new Configuration();
+        $configuration = new DefaultConfiguration();
         $this->expectException(UnknownConfigurationKey::class);
         $configuration->get('unknown_key');
     }
@@ -72,24 +72,24 @@ final class ConfigurationTest extends TestCase
     /**
      * Test whether invalid keys throw an exception.
      *
-     * @covers \AmpProject\Optimizer\Configuration::validateConfigurationKeys()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::validateConfigurationKeys()
      */
     public function testInvalidTransformersTypeThrowsException()
     {
         $this->expectException(InvalidConfigurationValue::class);
         $this->expectExceptionMessage("The configuration key 'transformers' expected a value of type 'array', got 'integer' instead.");
-        new Configuration([Configuration::KEY_TRANSFORMERS => 42]);
+        new DefaultConfiguration([Configuration::KEY_TRANSFORMERS => 42]);
     }
 
     /**
      * Test whether invalid sub-keys throw an exception.
      *
-     * @covers \AmpProject\Optimizer\Configuration::validateConfigurationKeys()
+     * @covers \AmpProject\Optimizer\DefaultConfiguration::validateConfigurationKeys()
      */
     public function testInvalidTransformersSubTypeThrowsException()
     {
         $this->expectException(InvalidConfigurationValue::class);
         $this->expectExceptionMessage("The configuration value '2' for the key 'transformers' expected a value of type 'string', got 'integer' instead.");
-        new Configuration([Configuration::KEY_TRANSFORMERS => ['first_one_is_good', 'second_one_is_good_as_well_but...', 42]]);
+        new DefaultConfiguration([Configuration::KEY_TRANSFORMERS => ['first_one_is_good', 'second_one_is_good_as_well_but...', 42]]);
     }
 }

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -213,7 +213,7 @@ final class SpecTest extends TestCase
             }
         }
 
-        return new Configuration($mappedConfiguration);
+        return new DefaultConfiguration($mappedConfiguration);
     }
 
     /**

--- a/tests/Optimizer/TransformationEngineTest.php
+++ b/tests/Optimizer/TransformationEngineTest.php
@@ -115,7 +115,7 @@ final class TransformationEngineTest extends TestCase
             ],
         ];
 
-        $configuration = new Configuration($configurationData);
+        $configuration = new DefaultConfiguration($configurationData);
         $configuration->registerConfigurationClass($transformerClass, TestTransformer\DummyTransformerConfiguration::class);
 
         $transformationEngine = $this->getTransformationEngine($configuration);


### PR DESCRIPTION
To make https://github.com/ampproject/amp-wp/issues/6064 possible, the `Configuration` object injected into the `TransformationEngine` class needs to be extensible in some form.

This PR turns the current final `Configuration` class into an interface and provides an implementation `DefaultConfiguration` to use as a starting point.