### PR TITLE
Add toArray() to transformer configuration

### DIFF
--- a/src/Optimizer/Configuration/BaseTransformerConfiguration.php
+++ b/src/Optimizer/Configuration/BaseTransformerConfiguration.php
@@ -63,6 +63,22 @@ abstract class BaseTransformerConfiguration implements TransformerConfiguration
     }
 
     /**
+     * Get an array of configuration entries for this transformer configuration.
+     *
+     * @return array Associative array of configuration entries.
+     */
+    public function toArray()
+    {
+        $configArray = [];
+
+        foreach (array_keys($this->allowedKeys) as $key) {
+            $configArray[$key] = $this->$key;
+        }
+
+        return $configArray;
+    }
+
+    /**
      * Get the associative array of allowed keys and their respective default values.
      *
      * The array index is the key and the array value is the key's default value.

--- a/src/Optimizer/TransformerConfiguration.php
+++ b/src/Optimizer/TransformerConfiguration.php
@@ -23,4 +23,11 @@ interface TransformerConfiguration
      * @throws UnknownConfigurationKey If an unknown key was provided.
      */
     public function get($key);
+
+    /**
+     * Get an array of configuration entries for this transformer configuration.
+     *
+     * @return array Associative array of configuration entries.
+     */
+    public function toArray();
 }

--- a/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
+++ b/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
@@ -28,6 +28,14 @@ final class AmpRuntimeCssConfigurationTest extends TestCase
         $this->assertEquals('', $configuration->styles);
         $this->assertEquals('', $configuration->get('version'));
         $this->assertEquals('', $configuration->version);
+        $this->assertEquals(
+            [
+                'canary'  => false,
+                'styles'  => '',
+                'version' => '',
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testInitialization()
@@ -46,6 +54,14 @@ final class AmpRuntimeCssConfigurationTest extends TestCase
         $this->assertEquals('h1: red;', $configuration->styles);
         $this->assertEquals('1.0', $configuration->get('version'));
         $this->assertEquals('1.0', $configuration->version);
+        $this->assertEquals(
+            [
+                'canary'  => true,
+                'styles'  => 'h1: red;',
+                'version' => '1.0',
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testThrowsOnInvalidKey()

--- a/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
+++ b/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
@@ -13,6 +13,7 @@ use stdClass;
  * Test the AmpBoilerplate transformer.
  *
  * @covers \AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration
+ * @covers \AmpProject\Optimizer\Configuration\BaseTransformerConfiguration
  * @package ampproject/amp-toolbox
  */
 final class AmpRuntimeCssConfigurationTest extends TestCase

--- a/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
+++ b/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
@@ -13,6 +13,7 @@ use stdClass;
  * Test the AmpBoilerplate transformer.
  *
  * @covers \AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration
+ * @covers \AmpProject\Optimizer\Configuration\BaseTransformerConfiguration
  * @package ampproject/amp-toolbox
  */
 final class PreloadHeroImageConfigurationTest extends TestCase

--- a/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
+++ b/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
@@ -28,6 +28,14 @@ final class PreloadHeroImageConfigurationTest extends TestCase
         $this->assertTrue($configuration->preloadHeroImage);
         $this->assertFalse($configuration->get('preloadSrcset'));
         $this->assertFalse($configuration->preloadSrcset);
+        $this->assertEquals(
+            [
+                'inlineStyleBackupAttribute' => '',
+                'preloadHeroImage'           => true,
+                'preloadSrcset'              => false,
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testInitialization()
@@ -46,6 +54,14 @@ final class PreloadHeroImageConfigurationTest extends TestCase
         $this->assertFalse($configuration->preloadHeroImage);
         $this->assertTrue($configuration->get('preloadSrcset'));
         $this->assertTrue($configuration->preloadSrcset);
+        $this->assertEquals(
+            [
+                'inlineStyleBackupAttribute' => 'style-backup',
+                'preloadHeroImage'           => false,
+                'preloadSrcset'              => true,
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testThrowsOnInvalidKey()

--- a/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
+++ b/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
@@ -14,6 +14,7 @@ use stdClass;
  * Test the AmpBoilerplate transformer.
  *
  * @covers \AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration
+ * @covers \AmpProject\Optimizer\Configuration\BaseTransformerConfiguration
  * @package ampproject/amp-toolbox
  */
 final class RewriteAmpUrlsConfigurationTest extends TestCase

--- a/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
+++ b/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
@@ -35,6 +35,17 @@ final class RewriteAmpUrlsConfigurationTest extends TestCase
         $this->assertFalse($configuration->lts);
         $this->assertFalse($configuration->get('rtv'));
         $this->assertFalse($configuration->rtv);
+        $this->assertEquals(
+            [
+                'ampRuntimeVersion' => '',
+                'ampUrlPrefix'      => Amp::CACHE_HOST,
+                'esmModulesEnabled' => true,
+                'geoApiUrl'         => '',
+                'lts'               => false,
+                'rtv'               => false,
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testInitialization()
@@ -62,6 +73,17 @@ final class RewriteAmpUrlsConfigurationTest extends TestCase
         $this->assertTrue($configuration->lts);
         $this->assertTrue($configuration->get('rtv'));
         $this->assertTrue($configuration->rtv);
+        $this->assertEquals(
+            [
+                'ampRuntimeVersion' => '123',
+                'ampUrlPrefix'      => 'amp/',
+                'esmModulesEnabled' => false,
+                'geoApiUrl'         => 'example.com/api',
+                'lts'               => true,
+                'rtv'               => true,
+            ],
+            $configuration->toArray()
+        );
     }
 
     public function testThrowsOnInvalidKey()

--- a/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
+++ b/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
@@ -13,6 +13,7 @@ use stdClass;
  * Test the AmpBoilerplate transformer.
  *
  * @covers \AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration
+ * @covers \AmpProject\Optimizer\Configuration\BaseTransformerConfiguration
  * @package ampproject/amp-toolbox
  */
 final class TransformedIdentifierConfigurationTest extends TestCase

--- a/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
+++ b/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
@@ -24,6 +24,7 @@ final class TransformedIdentifierConfigurationTest extends TestCase
         $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
         $this->assertEquals(1, $configuration->get('version'));
         $this->assertEquals(1, $configuration->version);
+        $this->assertEquals(['version' => 1], $configuration->toArray());
     }
 
     public function testInitialization()
@@ -36,6 +37,7 @@ final class TransformedIdentifierConfigurationTest extends TestCase
         $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
         $this->assertEquals(5, $configuration->get('version'));
         $this->assertEquals(5, $configuration->version);
+        $this->assertEquals(['version' => 5], $configuration->toArray());
     }
 
     public function testThrowsOnInvalidKey()

--- a/tests/src/TestTransformer/DummyTransformerConfiguration.php
+++ b/tests/src/TestTransformer/DummyTransformerConfiguration.php
@@ -10,4 +10,8 @@ final class DummyTransformerConfiguration implements TransformerConfiguration
     public function get($key)
     {
     }
+
+    public function toArray()
+    {
+    }
 }


### PR DESCRIPTION
To provide better insight into a configured optimizer pipeline, the `TransformerConfiguration` interface now requires its implementations to provides a `toArray()` method.

This method returns an associative array of all the configuration keys of that particular transformer configuration.