### PR TITLE
Replace Codecov bash uploader with GHA counterpart

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,15 @@ jobs:
 
       - name: Run tests with coverage
         if: ${{ matrix.coverage == true }}
-        run: |
-          vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-          bash <(curl -s https://codecov.io/bash) -cF php -f "$PWD/build/logs/clover.xml"
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Upload code coverage report
+        if: ${{ matrix.coverage == true }}
+        uses: codecov/codecov-action@v1.4.0
+        with:
+          file: build/logs/clover.xml
+          flags: php
+          fail_ci_if_error: true
 
   code-style:
     name: Code style / PHP ${{ matrix.php }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload code coverage report
         if: ${{ matrix.coverage == true }}
-        uses: codecov/codecov-action@v1.4.0
+        uses: codecov/codecov-action@v1.4.1
         with:
           file: build/logs/clover.xml
           flags: php


### PR DESCRIPTION
As of [v1.4.0](https://github.com/codecov/codecov-action/releases/tag/v1.4.0) the Codecov GHA calculates and verifies the checksum of the bash script used to upload code coverage reports.

This should help to prevent executing any unauthorized code if the bash script were to ever be compromised again (see https://about.codecov.io/security-update/).