### PR TITLE
Add OptimizeAmpBind transformer

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -49,6 +49,7 @@ interface Attribute
     const HOST_SERVICE             = 'host-service';
     const HREF                     = 'href';
     const HTTP_EQUIV               = 'http-equiv';
+    const I_AMPHTML_BINDING        = 'i-amphtml-binding';
     const I_AMPHTML_NO_BOILERPLATE = 'i-amphtml-no-boilerplate';
     const I_AMPHTML_SSR            = 'i-amphtml-ssr';
     const I_AMPHTML_VERSION        = 'i-amphtml-version';

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -21,8 +21,6 @@ use DOMText;
 use DOMXPath;
 
 /**
- * Class AmpProject\Dom\Document.
- *
  * Abstract away some of the difficulties of working with PHP's DOMDocument.
  *
  * @property DOMXPath     $xpath                   XPath query object for this document.

--- a/src/Dom/Element.php
+++ b/src/Dom/Element.php
@@ -10,7 +10,7 @@ use DOMElement;
 use DOMException;
 
 /**
- * Class AmpProject\Dom\Element.
+ * Abstract away some convenience logic for handling DOMElement objects.
  *
  * @property Document $ownerDocument        The ownerDocument for these elements should always be a Dom\Document.
  * @property int      $inlineStyleByteCount Number of bytes that are consumed by the inline style attribute.

--- a/src/Dom/ElementDump.php
+++ b/src/Dom/ElementDump.php
@@ -9,6 +9,8 @@ use DOMAttr;
  *
  * This is meant for quick identification of an element and does not dump the child element or other inner content
  * from that element.
+ *
+ * @package ampproject/amp-toolbox
  */
 final class ElementDump
 {

--- a/src/Dom/NodeWalker.php
+++ b/src/Dom/NodeWalker.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AmpProject\Dom;
+
+use DOMNode;
+
+/**
+ * Walk a hierarchical tree of nodes in a sequential manner.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class NodeWalker
+{
+
+    /**
+     * Depth-first walk through the DOM tree.
+     *
+     * @param DOMNode $node Node to start walking from.
+     * @return DOMNode|null Next node, or null if none found.
+     */
+    public static function nextNode(DOMNode $node)
+    {
+        // Walk downwards if there are children.
+        if ($node->firstChild) {
+            return $node->firstChild;
+        }
+
+        // Return direct sibling or walk upwards until we find a node with a sibling.
+        while ($node) {
+            if ($node->nextSibling) {
+                return $node->nextSibling;
+            }
+
+            $node = $node->parentNode;
+        }
+
+        // Out of nodes, so we're done.
+        return null;
+    }
+
+    /**
+     * Skip the subtree that is descending from the provided node.
+     *
+     * @param DOMNode $node Node to skip the subtree of.
+     * @return DOMNode|null The appropriate "next" node that will skip the current subtree, null if none found.
+     */
+    public static function skipNodeAndChildren(DOMNode $node)
+    {
+        if ($node->nextSibling) {
+            return $node->nextSibling;
+        }
+
+        return self::skipNodeAndChildren($node->parentNode);
+    }
+}

--- a/src/Dom/NodeWalker.php
+++ b/src/Dom/NodeWalker.php
@@ -50,6 +50,10 @@ final class NodeWalker
             return $node->nextSibling;
         }
 
+        if ($node->parentNode === null) {
+            return null;
+        }
+
         return self::skipNodeAndChildren($node->parentNode);
     }
 }

--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -6,6 +6,7 @@ use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
 use AmpProject\Optimizer\Transformer\AmpBoilerplate;
 use AmpProject\Optimizer\Transformer\AmpBoilerplateErrorHandler;
 use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
+use AmpProject\Optimizer\Transformer\OptimizeAmpBind;
 use AmpProject\Optimizer\Transformer\PreloadHeroImage;
 use AmpProject\Optimizer\Transformer\ReorderHead;
 use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
@@ -50,6 +51,7 @@ interface Configuration
         PreloadHeroImage::class,
         RewriteAmpUrls::class,
         ReorderHead::class,
+        OptimizeAmpBind::class,
     ];
 
     /**

--- a/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
@@ -3,7 +3,6 @@
 namespace AmpProject\Optimizer\Configuration;
 
 use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
-use AmpProject\RuntimeVersion;
 
 /**
  * Configuration for the OptimizeAmpBind transformer.

--- a/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AmpProject\Optimizer\Configuration;
+
+use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
+use AmpProject\RuntimeVersion;
+
+/**
+ * Configuration for the OptimizeAmpBind transformer.
+ *
+ * @property bool $enabled Whether the amp-bind optimizer is enabled.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class OptimizeAmpBindConfiguration extends BaseTransformerConfiguration
+{
+
+    /**
+     * Whether the amp-bind optimizer is enabled.
+     *
+     * @var bool
+     */
+    const ENABLED = 'enabled';
+
+    /**
+     * Get the associative array of allowed keys and their respective default values.
+     *
+     * The array index is the key and the array value is the key's default value.
+     *
+     * @return array Associative array of allowed keys and their respective default values.
+     */
+    protected function getAllowedKeys()
+    {
+        return [
+            self::ENABLED => true,
+        ];
+    }
+
+
+    /**
+     * Validate an individual configuration entry.
+     *
+     * @param string $key   Key of the configuration entry to validate.
+     * @param mixed  $value Value of the configuration entry to validate.
+     * @return mixed Validated value.
+     */
+    protected function validate($key, $value)
+    {
+        switch ($key) {
+            case self::ENABLED:
+                if (! is_bool($value)) {
+                    throw InvalidConfigurationValue::forInvalidSubValueType(
+                        self::class,
+                        self::ENABLED,
+                        'boolean',
+                        is_object($value) ? get_class($value) : gettype($value)
+                    );
+                }
+                break;
+        }
+
+        return $value;
+    }
+}

--- a/src/Optimizer/DefaultConfiguration.php
+++ b/src/Optimizer/DefaultConfiguration.php
@@ -3,6 +3,7 @@
 namespace AmpProject\Optimizer;
 
 use AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration;
+use AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration;
 use AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration;
 use AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration;
 use AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration;
@@ -10,6 +11,7 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
 use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
 use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
 use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
+use AmpProject\Optimizer\Transformer\OptimizeAmpBind;
 use AmpProject\Optimizer\Transformer\PreloadHeroImage;
 use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
 use AmpProject\Optimizer\Transformer\TransformedIdentifier;
@@ -40,6 +42,7 @@ class DefaultConfiguration implements Configuration
      */
     protected $transformerConfigurationClasses = [
         AmpRuntimeCss::class         => AmpRuntimeCssConfiguration::class,
+        OptimizeAmpBind::class       => OptimizeAmpBindConfiguration::class,
         PreloadHeroImage::class      => PreloadHeroImageConfiguration::class,
         RewriteAmpUrls::class        => RewriteAmpUrlsConfiguration::class,
         TransformedIdentifier::class => TransformedIdentifierConfiguration::class,

--- a/src/Optimizer/Transformer/OptimizeAmpBind.php
+++ b/src/Optimizer/Transformer/OptimizeAmpBind.php
@@ -78,15 +78,7 @@ final class OptimizeAmpBind implements Transformer
 
             /** @var DOMAttr $attribute */
             foreach ($node->attributes as $attribute) {
-                if (
-                    strpos($attribute->name, Document::AMP_BIND_DATA_ATTR_PREFIX) === 0
-                    ||
-                    (
-                        $attribute->name[0] === '['
-                        &&
-                        $attribute->name[strlen($attribute->name) - 1] === ']'
-                    )
-                ) {
+                if (strpos($attribute->name, Document::AMP_BIND_DATA_ATTR_PREFIX) === 0) {
                     $node->addBooleanAttribute(Attribute::I_AMPHTML_BINDING);
                     break;
                 }

--- a/src/Optimizer/Transformer/OptimizeAmpBind.php
+++ b/src/Optimizer/Transformer/OptimizeAmpBind.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace AmpProject\Optimizer\Transformer;
+
+use AmpProject\Amp;
+use AmpProject\Attribute;
+use AmpProject\Dom\Document;
+use AmpProject\Dom\Element;
+use AmpProject\Dom\NodeWalker;
+use AmpProject\Extension;
+use AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration;
+use AmpProject\Optimizer\ErrorCollection;
+use AmpProject\Optimizer\Transformer;
+use AmpProject\Optimizer\TransformerConfiguration;
+use AmpProject\Tag;
+use DOMAttr;
+
+/**
+ * OptimizeAmpBind - inject a querySelectorAll query-able i-amphtml-binding attribute on elements with bindings.
+ *
+ * This is ported from the NodeJS optimizer.
+ *
+ * NodeJS:
+ *
+ * @version 4aa99eb6e16a39bb562acb67efdfd3ee3d993a98
+ * @link https://github.com/ampproject/amp-toolbox/blob/4aa99eb6e16a39bb562acb67efdfd3ee3d993a98/packages/optimizer/lib/transformers/OptimizeAmpBind.js
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class OptimizeAmpBind implements Transformer
+{
+
+    /**
+     * Configuration store to use.
+     *
+     * @var TransformerConfiguration
+     */
+    private $configuration;
+
+    /**
+     * Instantiate an OptimizeAmpBind object.
+     *
+     * @param TransformerConfiguration $configuration Configuration store to use.
+     */
+    public function __construct(TransformerConfiguration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Apply transformations to the provided DOM document.
+     *
+     * @param Document        $document DOM document to apply the transformations to.
+     * @param ErrorCollection $errors   Collection of errors that are collected during transformation.
+     * @return void
+     */
+    public function transform(Document $document, ErrorCollection $errors)
+    {
+        if ($this->configuration->get(OptimizeAmpBindConfiguration::ENABLED) === false) {
+            return;
+        }
+
+        if (!$this->hasAmpBindScriptElement($document)) {
+            return;
+        }
+
+        $document->html->addBooleanAttribute(Attribute::I_AMPHTML_BINDING);
+
+        for ($node = $document->html; $node !== null; $node = NodeWalker::nextNode($node)) {
+            if (!$node instanceof Element) {
+                continue;
+            }
+
+            if (Amp::isTemplate($node)) {
+                $node = NodeWalker::skipNodeAndChildren($node);
+                continue;
+            }
+
+            /** @var DOMAttr $attribute */
+            foreach ($node->attributes as $attribute) {
+                if (
+                    strpos($attribute->name, Document::AMP_BIND_DATA_ATTR_PREFIX) === 0
+                    ||
+                    (
+                        $attribute->name[0] === '['
+                        &&
+                        $attribute->name[strlen($attribute->name) - 1] === ']'
+                    )
+                ) {
+                    $node->addBooleanAttribute(Attribute::I_AMPHTML_BINDING);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Check whether the document has an amp-bind script element.
+     *
+     * @param Document $document Document to check.
+     * @return bool Whether the document has an amp-bind script element.
+     */
+    private function hasAmpBindScriptElement(Document $document)
+    {
+        for ($element = $document->head->firstChild; $element !== null; $element = $element->nextSibling) {
+            if (!$element instanceof Element) {
+                continue;
+            }
+
+            if ($element->tagName !== Tag::SCRIPT) {
+                continue;
+            }
+
+            if ($element->getAttribute(Attribute::CUSTOM_ELEMENT) !== Extension::BIND) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -6,6 +6,7 @@ use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
 use AmpProject\Dom\Element;
+use AmpProject\Dom\NodeWalker;
 use AmpProject\Exception\FailedToParseUrl;
 use AmpProject\Extension;
 use AmpProject\Layout;
@@ -205,7 +206,7 @@ final class PreloadHeroImage implements Transformer
 
         while ($node !== null) {
             if (! $node instanceof Element) {
-                $node = $this->nextNode($node);
+                $node = NodeWalker::nextNode($node);
                 continue;
             }
 
@@ -240,9 +241,9 @@ final class PreloadHeroImage implements Transformer
 
             if (Amp::isTemplate($node)) {
                 // Ignore images inside templates.
-                $node = $this->skipNodeAndChildren($node);
+                $node = NodeWalker::skipNodeAndChildren($node);
             } else {
-                $node = $this->nextNode($node);
+                $node = NodeWalker::nextNode($node);
             }
         }
 
@@ -436,7 +437,7 @@ final class PreloadHeroImage implements Transformer
 
             while ($placeholder !== null) {
                 if (! $placeholder instanceof Element) {
-                    $placeholder = $this->nextNode($placeholder);
+                    $placeholder = NodeWalker::nextNode($placeholder);
                     continue;
                 }
 
@@ -450,9 +451,9 @@ final class PreloadHeroImage implements Transformer
 
                 if (Amp::isTemplate($placeholder)) {
                     // Ignore images inside templates.
-                    $placeholder = $this->skipNodeAndChildren($placeholder);
+                    $placeholder = NodeWalker::skipNodeAndChildren($placeholder);
                 } else {
-                    $placeholder = $this->nextNode($placeholder);
+                    $placeholder = NodeWalker::nextNode($placeholder);
                 }
             }
 
@@ -635,47 +636,6 @@ final class PreloadHeroImage implements Transformer
         }
 
         return false;
-    }
-
-    /**
-     * Depth-first walk through the DOM tree.
-     *
-     * @param DOMNode $node Node to start walking from.
-     * @return DOMNode|null Next node, or null if none found.
-     */
-    private function nextNode(DOMNode $node)
-    {
-        // Walk downwards if there are children.
-        if ($node->firstChild) {
-            return $node->firstChild;
-        }
-
-        // Return direct sibling or walk upwards until we find a node with a sibling.
-        while ($node) {
-            if ($node->nextSibling) {
-                return $node->nextSibling;
-            }
-
-            $node = $node->parentNode;
-        }
-
-        // Out of nodes, so we're done.
-        return null;
-    }
-
-    /**
-     * Skip the subtree that is descending from the provided node.
-     *
-     * @param DOMNode $node Node to skip the subtree of.
-     * @return DOMNode|null The appropriate "next" node that will skip the current subtree, null if none found.
-     */
-    private function skipNodeAndChildren(DOMNode $node)
-    {
-        if ($node->nextSibling) {
-            return $node->nextSibling;
-        }
-
-        return $this->skipNodeAndChildren($node->parentNode);
     }
 
     /**

--- a/tests/Dom/NodeWalkerTest.php
+++ b/tests/Dom/NodeWalkerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AmpProject\Dom;
+
+use AmpProject\Attribute;
+use AmpProject\Tests\TestCase;
+
+/**
+ * Tests for AmpProject\Dom\NodeWalker.
+ *
+ * @covers \AmpProject\Dom\NodeWalker
+ * @package ampproject/amp-toolbox
+ */
+class NodeWalkerTest extends TestCase
+{
+    const HTML = '
+        <div id="1"></div>
+        <div id="2">
+            <div id="3">
+                <div id="4"></div>
+            </div>
+        </div>
+        <div id="5"></div>
+        <div id="6">
+            <div id="7"></div>
+        </div>
+        <div id="8"></div>
+    ';
+
+    public function testNextNode()
+    {
+        $node   = Document::fromHtml(self::HTML)->body->firstChild;
+        $output = '';
+
+        while ($node !== null) {
+            if ($node instanceof Element) {
+                $output .= $node->getAttribute(Attribute::ID);
+            }
+
+            $node = NodeWalker::nextNode($node);
+        }
+
+        $this->assertEquals('12345678', $output);
+    }
+
+    public function testskipNodeAndChildren()
+    {
+        $node   = Document::fromHtml(self::HTML)->body->firstChild;
+        $output = '';
+
+        while ($node !== null) {
+            if ($node instanceof Element) {
+                $output .= $node->getAttribute(Attribute::ID);
+            }
+
+            $node = NodeWalker::skipNodeAndChildren($node);
+        }
+
+        $this->assertEquals('12568', $output);
+    }
+}

--- a/tests/Dom/NodeWalkerTest.php
+++ b/tests/Dom/NodeWalkerTest.php
@@ -8,7 +8,7 @@ use AmpProject\Tests\TestCase;
 /**
  * Tests for AmpProject\Dom\NodeWalker.
  *
- * @covers \AmpProject\Dom\NodeWalker
+ * @coversDefaultClass \AmpProject\Dom\NodeWalker
  * @package ampproject/amp-toolbox
  */
 class NodeWalkerTest extends TestCase
@@ -27,6 +27,7 @@ class NodeWalkerTest extends TestCase
         <div id="8"></div>
     ';
 
+    /** @covers ::nextNode() */
     public function testNextNode()
     {
         $node   = Document::fromHtml(self::HTML)->body->firstChild;
@@ -43,7 +44,8 @@ class NodeWalkerTest extends TestCase
         $this->assertEquals('12345678', $output);
     }
 
-    public function testskipNodeAndChildren()
+    /** @covers ::skipNodeAndChildren() */
+    public function testSkipNodeAndChildren()
     {
         $node   = Document::fromHtml(self::HTML)->body->firstChild;
         $output = '';

--- a/tests/Optimizer/Configuration/OptimizeAmpBindConfigurationTest.php
+++ b/tests/Optimizer/Configuration/OptimizeAmpBindConfigurationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace AmpProject\Optimizer\Configuration;
+
+use AmpProject\Optimizer\Exception\InvalidConfigurationKey;
+use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
+use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
+use AmpProject\Optimizer\TransformerConfiguration;
+use AmpProject\Tests\TestCase;
+use stdClass;
+
+/**
+ * Test the AmpBoilerplate transformer.
+ *
+ * @covers \AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration
+ * @covers \AmpProject\Optimizer\Configuration\BaseTransformerConfiguration
+ * @package ampproject/amp-toolbox
+ */
+final class OptimizeAmpBindConfigurationTest extends TestCase
+{
+
+    public function testDefaults()
+    {
+        $configuration = new OptimizeAmpBindConfiguration([]);
+        $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
+        $this->assertTrue($configuration->get('enabled'));
+        $this->assertTrue($configuration->enabled);
+        $this->assertEquals(
+            [
+                'enabled' => true,
+            ],
+            $configuration->toArray()
+        );
+    }
+
+    public function testInitialization()
+    {
+        $configuration = new OptimizeAmpBindConfiguration(
+            [
+                'enabled' => false,
+            ]
+        );
+        $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
+        $this->assertFalse($configuration->get('enabled'));
+        $this->assertFalse($configuration->enabled);
+        $this->assertEquals(
+            [
+                'enabled' => false,
+            ],
+            $configuration->toArray()
+        );
+    }
+
+    public function testThrowsOnInvalidKey()
+    {
+        $this->expectException(InvalidConfigurationKey::class);
+        $this->expectExceptionMessage(
+            "The provided configuration key 'nonsense' is not valid for the transformer 'OptimizeAmpBindConfiguration'."
+        );
+        new OptimizeAmpBindConfiguration(['nonsense'  => 'value']);
+    }
+
+    public function dataThrowsOnBadValueType()
+    {
+        return [
+            ['enabled', '42', 'boolean', 'string'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataThrowsOnBadValueType()
+     */
+    public function testThrowsOnBadValueType($key, $value, $expectedType, $actualType)
+    {
+        $this->expectException(InvalidConfigurationValue::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'The configuration value \'%s\' for the key \'%s\' expected a value of type \'%s\', got \'%s\' instead.',
+                $key,
+                OptimizeAmpBindConfiguration::class,
+                $expectedType,
+                $actualType
+            )
+        );
+
+        new OptimizeAmpBindConfiguration([$key  => $value]);
+    }
+
+    public function testThrowsOnUnknownKeyViaGetter()
+    {
+        $this->expectException(UnknownConfigurationKey::class);
+        $this->expectExceptionMessage(
+            "The configuration of the transformer 'OptimizeAmpBindConfiguration' does not contain the requested key 'nonsense'."
+        );
+        $configuration = new OptimizeAmpBindConfiguration([]);
+        $configuration->get('nonsense');
+    }
+
+    public function testThrowsOnUnknownKeyViaMagicMethod()
+    {
+        $this->expectError();
+        $this->expectErrorMessage(
+            'Undefined property: AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration::$nonsense'
+        );
+        $configuration = new OptimizeAmpBindConfiguration([]);
+        $configuration->nonsense;
+    }
+}

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -4,8 +4,10 @@ namespace AmpProject\Optimizer;
 
 use AmpProject\Dom\Document;
 use AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration;
+use AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration;
 use AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration;
 use AmpProject\Optimizer\Transformer\AmpBoilerplateErrorHandler;
+use AmpProject\Optimizer\Transformer\OptimizeAmpBind;
 use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
@@ -70,6 +72,10 @@ final class SpecTest extends TestCase
             'AmpRuntimeCss'                 => [
                 AmpRuntimeCss::class,
                 self::TRANSFORMER_SPEC_PATH . '/valid/AmpBoilerplateTransformer',
+            ],
+            'OptimizeAmpBind'               => [
+                OptimizeAmpBind::class,
+                self::TRANSFORMER_SPEC_PATH . '/experimental/OptimizeAmpBind',
             ],
             'PreloadHeroImage'              => [
                 PreloadHeroImage::class,
@@ -200,6 +206,9 @@ final class SpecTest extends TestCase
                     break;
                 case 'lts':
                     $mappedConfiguration[RewriteAmpUrls::class][RewriteAmpUrlsConfiguration::LTS] = $value;
+                    break;
+                case 'optimizeAmpBind':
+                    $mappedConfiguration[OptimizeAmpBind::class][OptimizeAmpBindConfiguration::ENABLED] = $value;
                     break;
                 case 'preloadHeroImage':
                     $mappedConfiguration[PreloadHeroImage::class][PreloadHeroImageConfiguration::PRELOAD_HERO_IMAGE] = $value;

--- a/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
+++ b/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
@@ -13,6 +13,7 @@ use AmpProject\Tests\TestCase;
  * Test the OptimizeAmpBind transformer.
  *
  * @covers \AmpProject\Optimizer\Transformer\OptimizeAmpBind
+ * @covers \AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration
  * @package ampproject/amp-toolbox
  */
 final class OptimizeAmpBindTest extends TestCase

--- a/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
+++ b/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace AmpProject\Optimizer\Transformer;
+
+use AmpProject\Attribute;
+use AmpProject\Dom\Document;
+use AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration;
+use AmpProject\Optimizer\ErrorCollection;
+use AmpProject\Tag;
+use AmpProject\Tests\TestCase;
+
+/**
+ * Test the OptimizeAmpBind transformer.
+ *
+ * @covers \AmpProject\Optimizer\Transformer\OptimizeAmpBind
+ * @package ampproject/amp-toolbox
+ */
+final class OptimizeAmpBindTest extends TestCase
+{
+
+    const HTML = '
+        <!doctype html>
+        <html ⚡>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width">
+            <script async src="https://cdn.ampproject.org/v0.js"></script>
+            <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+        </head>
+        <body>
+            <div data-amp-bind-text="foo">Hello, AMP world.</div>
+        </body>
+        </html>
+    ';
+
+    public function testEnabled()
+    {
+        $document      = Document::fromHtml(self::HTML);
+        $configuration = new OptimizeAmpBindConfiguration(
+            [
+                'enabled' => true,
+            ]
+        );
+
+        $transformer = new OptimizeAmpBind($configuration);
+        $transformer->transform($document, new ErrorCollection());
+        $this->assertTrue($document->html->hasAttribute(Attribute::I_AMPHTML_BINDING));
+        $this->assertTrue($document->body->getElementsByTagName(Tag::DIV)->item(0)->hasAttribute(Attribute::I_AMPHTML_BINDING));
+    }
+
+    public function testDisabled()
+    {
+        $document      = Document::fromHtml(self::HTML);
+        $configuration = new OptimizeAmpBindConfiguration(
+            [
+                'enabled' => false,
+            ]
+        );
+
+        $transformer = new OptimizeAmpBind($configuration);
+        $transformer->transform($document, new ErrorCollection());
+        $this->assertFalse($document->html->hasAttribute(Attribute::I_AMPHTML_BINDING));
+        $this->assertFalse($document->body->getElementsByTagName(Tag::DIV)->item(0)->hasAttribute(Attribute::I_AMPHTML_BINDING));
+    }
+}


### PR DESCRIPTION
This PR adds a new `OptimizeAmpBind` transformer that enables a considerably faster scanning method in `amp-bind`, by injecting an `i-amphtml-binding` attribute on all elements with a bound attribute.

Fixes #84
Depends on https://github.com/ampproject/amp-toolbox/pull/1217

Related https://github.com/ampproject/amp-toolbox/pull/1147