### PR TITLE
Point OptimizeAmpBind spec tests to valid instead of experimental

### DIFF
--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -75,7 +75,7 @@ final class SpecTest extends TestCase
             ],
             'OptimizeAmpBind'               => [
                 OptimizeAmpBind::class,
-                self::TRANSFORMER_SPEC_PATH . '/experimental/OptimizeAmpBind',
+                self::TRANSFORMER_SPEC_PATH . '/valid/OptimizeAmpBind',
             ],
             'PreloadHeroImage'              => [
                 PreloadHeroImage::class,


### PR DESCRIPTION
The spec test files for the `OptimizeAmpBind` transformer were moved upstream from `experimental` to `valid`.