### PR TITLE
Fix collection of preload nodes when v0.js is preloaded

### DIFF
--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -118,8 +118,9 @@ final class RewriteAmpUrls implements Transformer
 
         $node = $document->head->firstChild;
         while ($node) {
+            $nextSibling = $node->nextSibling;
             if (! $node instanceof Element) {
-                $node = $node->nextSibling;
+                $node = $nextSibling;
                 continue;
             }
 
@@ -158,7 +159,7 @@ final class RewriteAmpUrls implements Transformer
                 }
             }
 
-            $node = $node->nextSibling;
+            $node = $nextSibling;
         }
 
         return $preloadNodes;


### PR DESCRIPTION
In an AMP plugin [support topic](https://wordpress.org/support/topic/mjs-file-not-loading-in-standard-mode/), someone reported that the ESM scripts were not being added to the page. It turned out to be that they also had been manually preloading `v0.js` themselves:

```html
<link rel="preload" href="https://cdn.ampproject.org/v0.js" as="script" crossorigin="anonymous">
```

When `collectPreloadNodes` runs it removes any AMP scripts as it iterates over the nodes. The problem is that it removes the node which then causes the iteration to short-circuit because `$node->nextSibling` is empty once `$node` has been removed from the document:

https://github.com/ampproject/amp-toolbox-php/blob/5e3f8ee1d7cc69dbfd2024dfa734c5f2cfefb563/src/Optimizer/Transformer/RewriteAmpUrls.php#L153-L161

The fix is simply to store the `nextSibling` up-front so that it can be used safely anywhere thereafter in the loop.