### PR TITLE
Add SSR support for fluid layout

### DIFF
--- a/src/Amp.php
+++ b/src/Amp.php
@@ -109,12 +109,13 @@ final class Amp
     const RUNTIME = 'amp-runtime';
 
     // AMP classes reserved for internal use.
-    const LAYOUT_ATTRIBUTE          = 'i-amphtml-layout';
-    const NO_BOILERPLATE_ATTRIBUTE  = 'i-amphtml-no-boilerplate';
-    const LAYOUT_CLASS_PREFIX       = 'i-amphtml-layout-';
-    const LAYOUT_SIZE_DEFINED_CLASS = 'i-amphtml-layout-size-defined';
-    const SIZER_ELEMENT             = 'i-amphtml-sizer';
-    const INTRINSIC_SIZER_ELEMENT   = 'i-amphtml-intrinsic-sizer';
+    const LAYOUT_ATTRIBUTE           = 'i-amphtml-layout';
+    const NO_BOILERPLATE_ATTRIBUTE   = 'i-amphtml-no-boilerplate';
+    const LAYOUT_CLASS_PREFIX        = 'i-amphtml-layout-';
+    const LAYOUT_SIZE_DEFINED_CLASS  = 'i-amphtml-layout-size-defined';
+    const SIZER_ELEMENT              = 'i-amphtml-sizer';
+    const INTRINSIC_SIZER_ELEMENT    = 'i-amphtml-intrinsic-sizer';
+    const LAYOUT_AWAITING_SIZE_CLASS = 'i-amphtml-layout-awaiting-size';
 
     /**
      * Check if a given node is the AMP runtime script.

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -54,6 +54,7 @@ final class ServerSideRendering implements Transformer
         Layout::CONTAINER,
         Layout::FILL,
         Layout::FLEX_ITEM,
+        Layout::FLUID,
         Layout::INTRINSIC,
     ];
 
@@ -495,6 +496,13 @@ final class ServerSideRendering implements Transformer
             case Layout::FILL:
             case Layout::CONTAINER:
                 // Do nothing here.
+                break;
+            case Layout::FLUID:
+                if ($width->isDefined()) {
+                    $styles = "width:{$width->getNumeral()}{$width->getUnit()};";
+                }
+                $styles .= 'height:0;';
+                $this->addClass($element, AMP::LAYOUT_AWAITING_SIZE_CLASS);
                 break;
             case Layout::FLEX_ITEM:
                 if ($width->isDefined()) {

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -498,10 +498,7 @@ final class ServerSideRendering implements Transformer
                 // Do nothing here.
                 break;
             case Layout::FLUID:
-                if ($width->isDefined()) {
-                    $styles = "width:{$width->getNumeral()}{$width->getUnit()};";
-                }
-                $styles .= 'height:0;';
+                $styles .= 'width:100%;height:0;';
                 $this->addClass($element, AMP::LAYOUT_AWAITING_SIZE_CLASS);
                 break;
             case Layout::FLEX_ITEM:

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -498,7 +498,7 @@ final class ServerSideRendering implements Transformer
                 // Do nothing here.
                 break;
             case Layout::FLUID:
-                $styles .= 'width:100%;height:0;';
+                $styles = 'width:100%;height:0;';
                 $this->addClass($element, AMP::LAYOUT_AWAITING_SIZE_CLASS);
                 break;
             case Layout::FLEX_ITEM:

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -6,7 +6,6 @@ use AmpProject\Dom\Document;
 use AmpProject\Optimizer\Error;
 use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Optimizer\Exception\InvalidHtmlAttribute;
-use AmpProject\Tag;
 use AmpProject\Tests\ErrorComparison;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
@@ -316,6 +315,16 @@ final class ServerSideRenderingTest extends TestCase
                     '<style amp-custom>@media not screen and (min-width: 650px){#i-amp-0{display:none}}</style>'
                 ),
                 [],
+            ],
+
+            'amp-ad with fluid layout' => [
+                $input('<amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid"></amp-ad>'),
+                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" i-amphtml-layout="fluid" layout="fluid" style="height:0;" type="doubleclick"></amp-ad>'),
+            ],
+
+            'amp-ad with fluid layout and width defined' => [
+                $input('<amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid" width="300"></amp-ad>'),
+                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" width="300" i-amphtml-layout="fluid" layout="fluid" style="width:300px;height:0;" type="doubleclick"></amp-ad>'),
             ],
         ];
     }

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -319,12 +319,12 @@ final class ServerSideRenderingTest extends TestCase
 
             'amp-ad with fluid layout' => [
                 $input('<amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid"></amp-ad>'),
-                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" i-amphtml-layout="fluid" layout="fluid" style="height:0;" type="doubleclick"></amp-ad>'),
+                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" i-amphtml-layout="fluid" layout="fluid" style="width:100%;height:0;" type="doubleclick"></amp-ad>'),
             ],
 
             'amp-ad with fluid layout and width defined' => [
                 $input('<amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid" width="300"></amp-ad>'),
-                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" width="300" i-amphtml-layout="fluid" layout="fluid" style="width:300px;height:0;" type="doubleclick"></amp-ad>'),
+                $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" width="300" i-amphtml-layout="fluid" layout="fluid" style="width:100%;height:0;" type="doubleclick"></amp-ad>'),
             ],
         ];
     }


### PR DESCRIPTION
See corresponding PR https://github.com/ampproject/amp-toolbox/pull/1232.

**Update:** Validator change (https://github.com/ampproject/amphtml/commit/30a80a6a8ad40d9cf4ab7912426b6db7ed4945bb) has gone live. Compare [unoptimized](https://amp-ad-with-fluid-layout.glitch.me/unoptimized.html) with [optimized](https://amp-ad-with-fluid-layout.glitch.me/optimized.html).

~This is blocked by the AMP validator being updated, specifically to modify [`validateSsrLayout()`](https://github.com/ampproject/amphtml/blob/f2a49b8efa4ecb0cd1dd273977799299a9e1f816/validator/js/engine/validator.js#L4436-L4441) as follows:~

```diff
      const validInternalClasses = Object.create(null);
      validInternalClasses[getLayoutClass(layout)] = 0;
      if (isLayoutSizeDefined(layout)) {
        // i-amphtml-layout-size-defined
        validInternalClasses[getLayoutSizeDefinedClass()] = 0;
      }
+     if ('fluid' === layout) {
+       validInternalClasses['i-amphtml-layout-awaiting-size'] = 0;
+     }
```