### PR TITLE
Skip detecting ASCII when charset is set to "US-ASCII"

### DIFF
--- a/src/Dom/Document/Encoding.php
+++ b/src/Dom/Document/Encoding.php
@@ -39,7 +39,7 @@ interface Encoding
         // Assume ISO-8859-1 for some charsets.
         'latin-1' => 'ISO-8859-1',
         // US-ASCII is one of the most popular ASCII names and used as HTML charset,
-        // but mb_list_encodings contains only "ASCII"
+        // but mb_list_encodings contains only "ASCII".
         'us-ascii' => 'ascii',
     ];
 

--- a/src/Dom/Document/Encoding.php
+++ b/src/Dom/Document/Encoding.php
@@ -38,6 +38,9 @@ interface Encoding
     const MAPPINGS = [
         // Assume ISO-8859-1 for some charsets.
         'latin-1' => 'ISO-8859-1',
+        // US-ASCII is one of the most popular ASCII names and used as HTML charset,
+        // but mb_list_encodings contains only "ASCII"
+        'us-ascii' => 'ascii',
     ];
 
     /**


### PR DESCRIPTION
Problem: ASCII has an alternative name - US-ASCII but, PHP function mb_list_encodings knows only ASCII and sanitizes this encoding.

Solution: add US-ASCII to \AmpProject\Dom\Document\Encoding::MAPPINGS