### PR TITLE
Correct sort of transformers to fix preload hero images

### DIFF
--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -44,11 +44,11 @@ interface Configuration
      */
     const DEFAULT_TRANSFORMERS = [
         AmpBoilerplate::class,
+        PreloadHeroImage::class,
         ServerSideRendering::class,
         AmpRuntimeCss::class,
         AmpBoilerplateErrorHandler::class,
         TransformedIdentifier::class,
-        PreloadHeroImage::class,
         RewriteAmpUrls::class,
         ReorderHead::class,
         OptimizeAmpBind::class,


### PR DESCRIPTION
The first part of the fix for issue #204 

I think it is a good idea to add this small fix before adding the functionality of checking the right transformers order.