### PR TITLE
Conditionally add boilerplate error handler script depending on ESM, not transformed attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           extensions: dom, iconv, json, libxml, zip
           coverage: ${{ matrix.coverage && 'pcov' || 'none' }}
           ini-values: pcov.directory=.
-          tools: composer, cs2pr
+          tools: composer
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -44,11 +44,6 @@ jobs:
 
       - name: Install Composer dependencies
         run: composer install
-
-      # Scan the logs for failing tests and surface that information by creating annotations and log file decorations.
-      - name: Setup problem matcher to provide annotations for PHPUnit
-        # The JSON file is provided by the `shivammathur/setup-php` action. See https://github.com/shivammathur/setup-php#problem-matchers.
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run tests
         if: ${{ matrix.coverage == false }}

--- a/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
+++ b/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
@@ -20,6 +20,15 @@ final class AmpBoilerplateErrorHandler implements Transformer
 {
 
     /**
+     * XPath query to find an AMP runtime script using ES6 modules.
+     *
+     * Note that substring() is used as ends-with() requires XPath 2.0, but PHP comes with XPath 1.0 support only.
+     *
+     * @var string
+     */
+    const AMP_MODULAR_RUNTIME_XPATH_QUERY = './script[substring(@src, string-length(@src) - 6) = \'/v0.mjs\']';
+
+    /**
      * Error handler script to be added to the document's <head> for AMP pages not using ES modules.
      *
      * @var string
@@ -59,10 +68,21 @@ final class AmpBoilerplateErrorHandler implements Transformer
                 [
                     Attribute::AMP_ONERROR => null,
                 ],
-                $document->html->hasAttribute(Attribute::I_AMPHTML_MODULE) ?
-                    self::ERROR_HANDLER_MODULE :
-                    self::ERROR_HANDLER_NOMODULE
+                $this->usesModules($document) ? self::ERROR_HANDLER_MODULE : self::ERROR_HANDLER_NOMODULE
             )
         );
+    }
+
+    /**
+     * Check whether a provided document uses ES6 modules.
+     *
+     * @param Document $document Document to check.
+     * @return bool Whether the provided document uses ES6 modules.
+     */
+    private function usesModules(Document $document)
+    {
+        $scripts = $document->xpath->query(self::AMP_MODULAR_RUNTIME_XPATH_QUERY, $document->head);
+
+        return $scripts->length > 0;
     }
 }

--- a/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
+++ b/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
@@ -20,24 +20,24 @@ final class AmpBoilerplateErrorHandler implements Transformer
 {
 
     /**
-     * Error handler script to be added to the document's <head> for non-transformed AMP pages.
+     * Error handler script to be added to the document's <head> for AMP pages not using ES modules.
      *
      * @var string
      */
-    const ERROR_HANDLER_NOT_TRANSFORMED = 'document.querySelector("script[src*=\'/v0.js\']").onerror=function(){'
-                                          . 'document.querySelector(\'style[amp-boilerplate]\').textContent=\'\'}';
+    const ERROR_HANDLER_NOMODULE = 'document.querySelector("script[src*=\'/v0.js\']").onerror=function(){'
+                                   . 'document.querySelector(\'style[amp-boilerplate]\').textContent=\'\'}';
 
     /**
-     * Error handler script to be added to the document's <head> for transformed AMP pages.
+     * Error handler script to be added to the document's <head> for AMP pages using ES modules.
      *
      * @var string
      */
-    const ERROR_HANDLER_TRANSFORMED = '[].slice.call(document.querySelectorAll('
-                                      . '"script[src*=\'/v0.js\'],script[src*=\'/v0.mjs\']")).forEach('
-                                      . 'function(s){s.onerror='
-                                      . 'function(){'
-                                      . 'document.querySelector(\'style[amp-boilerplate]\').textContent=\'\''
-                                      . '}})';
+    const ERROR_HANDLER_MODULE = '[].slice.call(document.querySelectorAll('
+                                 . '"script[src*=\'/v0.js\'],script[src*=\'/v0.mjs\']")).forEach('
+                                 . 'function(s){s.onerror='
+                                 . 'function(){'
+                                 . 'document.querySelector(\'style[amp-boilerplate]\').textContent=\'\''
+                                 . '}})';
 
     /**
      * Apply transformations to the provided DOM document.
@@ -59,9 +59,9 @@ final class AmpBoilerplateErrorHandler implements Transformer
                 [
                     Attribute::AMP_ONERROR => null,
                 ],
-                $document->html->hasAttribute(Transformer\TransformedIdentifier::TRANSFORMED_ATTRIBUTE) ?
-                    self::ERROR_HANDLER_TRANSFORMED :
-                    self::ERROR_HANDLER_NOT_TRANSFORMED
+                $document->html->hasAttribute(Attribute::I_AMPHTML_MODULE) ?
+                    self::ERROR_HANDLER_MODULE :
+                    self::ERROR_HANDLER_NOMODULE
             )
         );
     }

--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -104,10 +104,6 @@ final class RewriteAmpUrls implements Transformer
     {
         $usesEsm = $this->configuration->get(RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED);
 
-        if ($usesEsm) {
-            $document->html->setAttribute(Attribute::I_AMPHTML_MODULE, null);
-        }
-
         $node = $document->head->firstChild;
         while ($node) {
             $nextSibling = $node->nextSibling;

--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -104,6 +104,10 @@ final class RewriteAmpUrls implements Transformer
     {
         $usesEsm = $this->configuration->get(RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED);
 
+        if ($usesEsm) {
+            $document->html->setAttribute(Attribute::I_AMPHTML_MODULE, null);
+        }
+
         $node = $document->head->firstChild;
         while ($node) {
             $nextSibling = $node->nextSibling;

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -44,8 +44,6 @@ final class SpecTest extends TestCase
 
         'PreloadHeroImage - max-hero-image-count-param'    => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
         'PreloadHeroImage - disable_via_param'             => 'see https://github.com/ampproject/amp-toolbox-php/issues/55',
-
-        'AmpBoilerplateErrorHandler - adds_error_handler_when_boilerplate_present' => 'see https://github.com/ampproject/amp-toolbox-php/pull/218',
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';

--- a/tests/Optimizer/Transformer/AmpBoilerplateErrorHandlerTest.php
+++ b/tests/Optimizer/Transformer/AmpBoilerplateErrorHandlerTest.php
@@ -29,7 +29,7 @@ final class AmpBoilerplateErrorHandlerTest extends TestCase
     public function dataTransform()
     {
         return [
-            'error handler is added if boilerplate present on non-transformed AMP page' => [
+            'error handler is added if boilerplate present on AMP page without modules' => [
                 TestMarkup::DOCTYPE . '<html ⚡><head>' .
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
@@ -40,22 +40,22 @@ final class AmpBoilerplateErrorHandlerTest extends TestCase
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
                 TestMarkup::STYLE_AMPRUNTIME . TestMarkup::SCRIPT_AMPRUNTIME .
-                '<script amp-onerror>' . AmpBoilerplateErrorHandler::ERROR_HANDLER_NOT_TRANSFORMED . '</script>' .
+                '<script amp-onerror>' . AmpBoilerplateErrorHandler::ERROR_HANDLER_NOMODULE . '</script>' .
                 '</head><body></body></html>',
             ],
 
-            'error handler is added if boilerplate present on transformed AMP page' => [
-                TestMarkup::DOCTYPE . '<html ⚡ transformed="self;v=1"><head>' .
+            'error handler is added if boilerplate present on AMP page with modules' => [
+                TestMarkup::DOCTYPE . '<html ⚡><head>' .
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
-                TestMarkup::STYLE_AMPRUNTIME . TestMarkup::SCRIPT_AMPRUNTIME .
+                TestMarkup::STYLE_AMPRUNTIME . TestMarkup::SCRIPT_AMPRUNTIME_ESM .
                 '</head><body></body></html>',
 
-                TestMarkup::DOCTYPE . '<html ⚡ transformed="self;v=1"><head>' .
+                TestMarkup::DOCTYPE . '<html ⚡><head>' .
                 TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT .
                 TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE .
-                TestMarkup::STYLE_AMPRUNTIME . TestMarkup::SCRIPT_AMPRUNTIME .
-                '<script amp-onerror>' . AmpBoilerplateErrorHandler::ERROR_HANDLER_TRANSFORMED . '</script>' .
+                TestMarkup::STYLE_AMPRUNTIME . TestMarkup::SCRIPT_AMPRUNTIME_ESM .
+                '<script amp-onerror>' . AmpBoilerplateErrorHandler::ERROR_HANDLER_MODULE . '</script>' .
                 '</head><body></body></html>',
             ],
 

--- a/tests/src/TestMarkup.php
+++ b/tests/src/TestMarkup.php
@@ -85,6 +85,9 @@ final class TestMarkup
     // ScriptAMPRuntime is the AMP script tag.
     const SCRIPT_AMPRUNTIME = '<script async src="https://cdn.ampproject.org/v0.js"></script>';
 
+    // ScriptAMPRuntimeEsm is the AMP script tag when using ES6 modules.
+    const SCRIPT_AMPRUNTIME_ESM = '<script async crossorigin="anonymous" nomodule src="https://cdn.ampproject.org/v0.js"></script><script async crossorigin="anonymous" src="https://cdn.ampproject.org/v0.mjs" type="module"></script>';
+
     // ScriptAMPViewerRuntime is the AMP viewer runtime script tag.
     const SCRIPT_AMPVIEWER_RUNTIME = '<script async src="https://cdn.ampproject.org/v0/amp-viewer-integration-0.1.js"></script>';
 


### PR DESCRIPTION
Instead of making the boilerplate error handler syntax depend on the `transformed` flag, it should depend on whether ESM is being used.

This PR lets the `RewriteAmpUrls` transformer add an `<html>` attribute `i-amphtml-module` if ESM is enabled, and then checks this attribute to decide which variant of the boilerplate error handler to use.