### PR TITLE
Add codecov token

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  token: 9ce03549-9167-4989-a3a0-4aaef39399c4
+
 coverage:
   status:
     # Patch-level coverage (how well is the PR tested)


### PR DESCRIPTION
This PR adds a token to the codecov configuration file which helps codecov unambiguously identify the repository to send the coverage results to.