### PR TITLE
Use maxBytes from Spec instead of hard-coding it

### DIFF
--- a/src/Amp.php
+++ b/src/Amp.php
@@ -117,15 +117,6 @@ final class Amp
     const INTRINSIC_SIZER_ELEMENT   = 'i-amphtml-intrinsic-sizer';
 
     /**
-     * Maximum size of the CSS styles in bytes.
-     *
-     * @todo Max size is hard-coded for now until we ported over the generated spec into a reusable package.
-     *
-     * @var int
-     */
-    const MAX_CSS_BYTE_COUNT = 75000;
-
-    /**
      * Check if a given node is the AMP runtime script.
      *
      * The AMP runtime script node is of the form '<script async src="https://cdn.ampproject.org...v0.js"></script>'.

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -11,7 +11,7 @@ use AmpProject\Exception\InvalidByteSequence;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Optimizer\CssRule;
 use AmpProject\Tag;
-use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\CssRuleset\AmpNoTransformed;
 use AmpProject\Validator\Spec\SpecRule;
 use DOMAttr;
 use DOMComment;
@@ -2107,13 +2107,14 @@ final class Document extends DOMDocument
     /**
      * Enforce a maximum number of bytes for the CSS.
      *
-     * @param int $maxByteCount Maximum number of bytes to limit the CSS to. A negative number disables the limit.
+     * @param int|null $maxByteCount Maximum number of bytes to limit the CSS to. A negative number disables the limit.
+     *                               If null then the max bytes from AmpNoTransformed is used.
      */
     public function enforceCssMaxByteCount($maxByteCount = null)
     {
         if ($maxByteCount === null) {
             // No need to instantiate the spec here, we can just directly reference the needed constant.
-            $maxByteCount = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+            $maxByteCount = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
         }
 
         $this->cssMaxByteCountEnforced = $maxByteCount;

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -2,7 +2,6 @@
 
 namespace AmpProject\Dom;
 
-use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\DevMode;
 use AmpProject\Dom\Document\Encoding;
@@ -12,6 +11,9 @@ use AmpProject\Exception\InvalidByteSequence;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Optimizer\CssRule;
 use AmpProject\Tag;
+use AmpProject\Validator\Spec;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 use DOMAttr;
 use DOMComment;
 use DOMDocument;
@@ -2108,8 +2110,13 @@ final class Document extends DOMDocument
      *
      * @param int $maxByteCount Maximum number of bytes to limit the CSS to. A negative number disables the limit.
      */
-    public function enforceCssMaxByteCount($maxByteCount = Amp::MAX_CSS_BYTE_COUNT)
+    public function enforceCssMaxByteCount($maxByteCount = null)
     {
+        if ($maxByteCount === null) {
+            // No need to instantiate the spec here, we can just directly reference the needed constant.
+            $maxByteCount = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        }
+
         $this->cssMaxByteCountEnforced = $maxByteCount;
     }
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -11,7 +11,6 @@ use AmpProject\Exception\InvalidByteSequence;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Optimizer\CssRule;
 use AmpProject\Tag;
-use AmpProject\Validator\Spec;
 use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
 use AmpProject\Validator\Spec\SpecRule;
 use DOMAttr;

--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -43,11 +43,11 @@ interface Configuration
      * @var string[]
      */
     const DEFAULT_TRANSFORMERS = [
+        TransformedIdentifier::class,
         AmpBoilerplate::class,
         PreloadHeroImage::class,
         ServerSideRendering::class,
         AmpRuntimeCss::class,
-        TransformedIdentifier::class,
         AmpBoilerplateErrorHandler::class,
         RewriteAmpUrls::class,
         ReorderHead::class,

--- a/src/Optimizer/Transformer/TransformedIdentifier.php
+++ b/src/Optimizer/Transformer/TransformedIdentifier.php
@@ -7,6 +7,8 @@ use AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration;
 use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Optimizer\Transformer;
 use AmpProject\Optimizer\TransformerConfiguration;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 
 /**
  * Transformer applying the transformed identifier transformations to the HTML input.
@@ -67,6 +69,10 @@ final class TransformedIdentifier implements Transformer
     public function transform(Document $document, ErrorCollection $errors)
     {
         $document->html->setAttribute(self::TRANSFORMED_ATTRIBUTE, $this->getOrigin());
+
+        // Ensure that the document uses the larges CSS byte limit for transformed documents,
+        // as it would probably be set to the non-transformed limit at this point.
+        $document->enforceCssMaxByteCount(AmpTransformed::SPEC[SpecRule::MAX_BYTES]);
     }
 
     /**

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -2,7 +2,6 @@
 
 namespace AmpProject\Dom;
 
-use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document\Option;
 use AmpProject\Exception\InvalidByteSequence;

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -10,6 +10,8 @@ use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 use DOMNode;
 
 /**
@@ -1007,10 +1009,12 @@ class DocumentTest extends TestCase
      */
     public function testGetRemainingCssSpace()
     {
+        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
         $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
-        $ampCustomStyle->textContent = str_pad('', Amp::MAX_CSS_BYTE_COUNT - 10, 'X');
+        $ampCustomStyle->textContent = str_pad('', $maxBytes - 10, 'X');
         $document->head->appendChild($ampCustomStyle);
 
         /** @var Element $element */
@@ -1019,7 +1023,7 @@ class DocumentTest extends TestCase
         $element->addInlineStyle('12345');
 
         $this->assertEquals(PHP_INT_MAX, $document->getRemainingCustomCssSpace());
-        $document->enforceCssMaxByteCount(Amp::MAX_CSS_BYTE_COUNT);
+        $document->enforceCssMaxByteCount($maxBytes);
         $this->assertEquals(5, $document->getRemainingCustomCssSpace());
     }
 
@@ -1031,10 +1035,12 @@ class DocumentTest extends TestCase
      */
     public function testAddAmpCustomStyleWithoutLimit()
     {
+        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
         $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
-        $ampCustomStyle->textContent = str_pad('', Amp::MAX_CSS_BYTE_COUNT - 28, 'X');
+        $ampCustomStyle->textContent = str_pad('', $maxBytes - 28, 'X');
         $document->head->appendChild($ampCustomStyle);
 
         // Custom styles can be added.
@@ -1056,11 +1062,13 @@ class DocumentTest extends TestCase
      */
     public function testAddAmpCustomStyleWithLimit()
     {
+        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+
         $document = new Document();
-        $document->enforceCssMaxByteCount(Amp::MAX_CSS_BYTE_COUNT);
+        $document->enforceCssMaxByteCount($maxBytes);
         $ampCustomStyle = $document->createElement(Tag::STYLE);
         $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
-        $ampCustomStyle->textContent = str_pad('', Amp::MAX_CSS_BYTE_COUNT - 28, 'X');
+        $ampCustomStyle->textContent = str_pad('', $maxBytes - 28, 'X');
         $document->head->appendChild($ampCustomStyle);
 
         // Custom styles can be added.

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -9,7 +9,7 @@ use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
-use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\CssRuleset\AmpNoTransformed;
 use AmpProject\Validator\Spec\SpecRule;
 use DOMNode;
 
@@ -1008,7 +1008,7 @@ class DocumentTest extends TestCase
      */
     public function testGetRemainingCssSpace()
     {
-        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        $maxBytes = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
 
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
@@ -1034,7 +1034,7 @@ class DocumentTest extends TestCase
      */
     public function testAddAmpCustomStyleWithoutLimit()
     {
-        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        $maxBytes = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
 
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
@@ -1061,7 +1061,7 @@ class DocumentTest extends TestCase
      */
     public function testAddAmpCustomStyleWithLimit()
     {
-        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        $maxBytes = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
 
         $document = new Document();
         $document->enforceCssMaxByteCount($maxBytes);

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -2,7 +2,6 @@
 
 namespace AmpProject\Dom;
 
-use AmpProject\Amp;
 use AmpProject\Attribute;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -7,6 +7,8 @@ use AmpProject\Attribute;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;
 use AmpProject\Tests\TestCase;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 
 /**
  * Tests for AmpProject\Dom\Element.
@@ -59,10 +61,12 @@ class ElementTest extends TestCase
      */
     public function testAddInlineStyleWithoutLimit()
     {
+        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
         $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
-        $ampCustomStyle->textContent = str_pad('', Amp::MAX_CSS_BYTE_COUNT - 38, 'X');
+        $ampCustomStyle->textContent = str_pad('', $maxBytes - 38, 'X');
         $document->head->appendChild($ampCustomStyle);
 
         /** @var Element $element */
@@ -92,11 +96,13 @@ class ElementTest extends TestCase
      */
     public function testAddInlineStyleWithLimit()
     {
+        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+
         $document = new Document();
-        $document->enforceCssMaxByteCount(Amp::MAX_CSS_BYTE_COUNT);
+        $document->enforceCssMaxByteCount($maxBytes);
         $ampCustomStyle = $document->createElement(Tag::STYLE);
         $ampCustomStyle->setAttribute(Attribute::AMP_CUSTOM, null);
-        $ampCustomStyle->textContent = str_pad('', Amp::MAX_CSS_BYTE_COUNT - 38, 'X');
+        $ampCustomStyle->textContent = str_pad('', $maxBytes - 38, 'X');
         $document->head->appendChild($ampCustomStyle);
 
         /** @var Element $element */

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -6,7 +6,7 @@ use AmpProject\Attribute;
 use AmpProject\Exception\MaxCssByteCountExceeded;
 use AmpProject\Tag;
 use AmpProject\Tests\TestCase;
-use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\CssRuleset\AmpNoTransformed;
 use AmpProject\Validator\Spec\SpecRule;
 
 /**
@@ -60,7 +60,7 @@ class ElementTest extends TestCase
      */
     public function testAddInlineStyleWithoutLimit()
     {
-        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        $maxBytes = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
 
         $document = new Document();
         $ampCustomStyle = $document->createElement(Tag::STYLE);
@@ -95,7 +95,7 @@ class ElementTest extends TestCase
      */
     public function testAddInlineStyleWithLimit()
     {
-        $maxBytes = AmpTransformed::SPEC[SpecRule::MAX_BYTES];
+        $maxBytes = AmpNoTransformed::SPEC[SpecRule::MAX_BYTES];
 
         $document = new Document();
         $document->enforceCssMaxByteCount($maxBytes);

--- a/tests/Optimizer/TransformationEngineTest.php
+++ b/tests/Optimizer/TransformationEngineTest.php
@@ -23,7 +23,7 @@ final class TransformationEngineTest extends TestCase
 
     const MINIMAL_HTML_MARKUP           = '<html></html>';
     const MINIMAL_OPTIMIZED_HTML_MARKUP = TestMarkup::DOCTYPE .
-                                          '<html i-amphtml-layout="" i-amphtml-no-boilerplate="" transformed="self;v=1"><head>' .
+                                          '<html transformed="self;v=1" i-amphtml-layout="" i-amphtml-no-boilerplate=""><head>' .
                                           TestMarkup::META_CHARSET .
                                           '<style amp-runtime="" i-amphtml-version="012345678900000">/* v0.css */</style>' .
                                           '</head><body></body></html>';


### PR DESCRIPTION
We had initially hard-coded the `maxBytes` spec value for enforcing the byte limit on CSS.

This PR changes the code to use the spec value directly instead.

Note that the hard-coded value was already stale, so this also fixes a bug.