### PR TITLE
Preserve mustache tag wrapped in comment inside template element

### DIFF
--- a/src/Optimizer/Transformer/MinifyHtml.php
+++ b/src/Optimizer/Transformer/MinifyHtml.php
@@ -5,6 +5,7 @@ namespace AmpProject\Optimizer\Transformer;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
 use AmpProject\Dom\Element;
+use AmpProject\Extension;
 use AmpProject\Optimizer\Configuration\MinifyHtmlConfiguration;
 use AmpProject\Optimizer\Error\InvalidJson;
 use AmpProject\Optimizer\ErrorCollection;
@@ -29,6 +30,13 @@ final class MinifyHtml implements Transformer
      * @var TransformerConfiguration
      */
     private $configuration;
+
+    /**
+     * Whether the nodes being minified are inside a mustache template.
+     *
+     * @var bool
+     */
+    private $isInsideMustacheTemplate = false;
 
     /**
      * Instantiate a MinifyHtml object.
@@ -98,11 +106,19 @@ final class MinifyHtml implements Transformer
         }
 
         if ($node->hasChildNodes()) {
+            if ($this->isMustacheTemplate($node)) {
+                $this->isInsideMustacheTemplate = true;
+            }
+
             foreach ($node->childNodes as $childNode) {
                 $nodesToRemove = array_merge(
                     $nodesToRemove,
                     $this->minifyNode($childNode, $errors, $canCollapseWhitespace, $inBody)
                 );
+            }
+
+            if ($this->isMustacheTemplate($node)) {
+                $this->isInsideMustacheTemplate = false;
             }
         }
 
@@ -158,6 +174,10 @@ final class MinifyHtml implements Transformer
 
         // In case the main $document has `securedDoctype`.
         if (preg_match('/^amp-doctype html/i', $node->data)) {
+            return [];
+        }
+
+        if ($this->isInsideMustacheTemplate && preg_match($this->getMustacheTagPattern(), $node->data)) {
             return [];
         }
 
@@ -244,5 +264,60 @@ final class MinifyHtml implements Transformer
             // PHP uses uppercase letters for angle bracket codes, so convert them into lowercase.
             $node->data = str_replace(['\u003E', '\u003C'], ['\u003e', '\u003c'], $data);
         }
+    }
+
+    /**
+     * Checks if a node is amp-mustache template.
+     *
+     * @param DOMNode $node The dom node need to be checked.
+     * @return bool Whether the checked element is an amp-mustache template.
+     */
+    private function isMustacheTemplate(DOMNode $node)
+    {
+        if (
+            $node instanceof Element &&
+            $node->tagName === Tag::TEMPLATE &&
+            $node->getAttribute(Attribute::TYPE) === Extension::MUSTACHE
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get a regular expression that matches all amp-mustache tags while consuming whitespace.
+     *
+     * @return string Regex pattern to match amp-mustache tags with whitespace.
+     */
+    private function getMustacheTagPattern()
+    {
+        static $tagPattern = null;
+
+        if (null === $tagPattern) {
+            $delimiter = ':';
+            $tags      = [];
+            $tokens    = [
+                '{{{',
+                '}}}',
+                '{{#',
+                '{{^',
+                '{{/',
+                '{{',
+                '}}',
+            ];
+
+            foreach ($tokens as $token) {
+                if ('{' === $token[0]) {
+                    $tags[] = preg_quote($token, $delimiter) . '\s*';
+                } else {
+                    $tags[] = '\s*' . preg_quote($token, $delimiter);
+                }
+            }
+
+            $tagPattern = $delimiter . implode('|', $tags) . $delimiter;
+        }
+
+        return $tagPattern;
     }
 }

--- a/src/Optimizer/Transformer/MinifyHtml.php
+++ b/src/Optimizer/Transformer/MinifyHtml.php
@@ -32,7 +32,7 @@ final class MinifyHtml implements Transformer
     private $configuration;
 
     /**
-     * Whether the nodes being minified are inside a mustache template.
+     * Whether the node(s) being minified are inside a mustache template.
      *
      * @var bool
      */
@@ -267,10 +267,10 @@ final class MinifyHtml implements Transformer
     }
 
     /**
-     * Checks if a node is amp-mustache template.
+     * Checks if a node is an amp-mustache template element.
      *
-     * @param DOMNode $node The dom node need to be checked.
-     * @return bool Whether the checked element is an amp-mustache template.
+     * @param DOMNode $node The dom node to be checked.
+     * @return bool Whether the checked node is an amp-mustache template element.
      */
     private function isMustacheTemplate(DOMNode $node)
     {

--- a/tests/Optimizer/Transformer/MinifyHtmlTest.php
+++ b/tests/Optimizer/Transformer/MinifyHtmlTest.php
@@ -87,14 +87,46 @@ final class MinifyHtmlTest extends TestCase
                 [
                     new InvalidJson('Error decoding JSON: Syntax error'),
                 ]
-            ]
+            ],
+            'mustache template with commented template tags' => [
+                TestMarkup::DOCTYPE . '<html ⚡> <head> ' .
+                TestMarkup::META_CHARSET .
+                ' </head> <body>' .
+                '    <!-- Comment before template. -->' .
+                '    <amp-list src="cart.json" layout="fixed-height" height="80" binding="no">' .
+                '        <template type="amp-mustache">' .
+                '            <div id="cart">' .
+                '                <!-- Comment inside template but not a template tag. -->' .
+                '                <table>' .
+                '                    <tr>' .
+                '                        <!-- {{#cart_items}} -->' .
+                '                        <td>{{name}}</td>' .
+                '                        <!-- {{/cart_items}} -->' .
+                '                    </tr>' .
+                '                </table>' .
+                '            </div>' .
+                '        </template>' .
+                '    </amp-list>' .
+                '    <p>Hello <strong>World</strong></p>' .
+                '    <!-- Comment before closing body tag. -->' .
+                '</body> </html>',
+                TestMarkup::DOCTYPE . '<html ⚡><head>' .
+                TestMarkup::META_CHARSET .
+                '</head><body>' .
+                '<amp-list src="cart.json" layout="fixed-height" height="80" binding="no"> ' .
+                '<template type="amp-mustache"> <div id="cart">  ' .
+                '<table> <tr> <!-- {{#cart_items}} --> <td>{{name}}</td> <!-- {{/cart_items}} --> </tr> </table> ' .
+                '</div> </template> ' .
+                '</amp-list> <p>Hello <strong>World</strong></p>' .
+                '</body></html>',
+            ],
         ];
     }
 
     /**
      * Test the transform() method.
      *
-     * @covers       \AmpProject\Optimizer\Transformer\AmpBoilerplate::transform()
+     * @covers       \AmpProject\Optimizer\Transformer\MinifyHtml::transform()
      * @dataProvider dataTransform()
      *
      * @param string                  $source         String of source HTML.


### PR DESCRIPTION
In an amp-mustache template, user may wrap the mustache tags inside HTML comment. One of the reason behind this may be to avoid the foster parenting. Hence we could have a template like this,
```
<template type="amp-mustache">
  <div id="cart">
    <table>
      <tr>
        <!-- {{#cart_items}} -->
        <td>{{name}}</td>
        <!-- {{/cart_items}} -->
      </tr>
    </table>
  </div>
</template>
```

The current MinifyHTML transformer removes the template tags inside the comments. The goal of this PR is to preserve these template tags and fix the issue.

Fixes #285.