### PR TITLE
Disable the Codecov annotations check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,3 +19,6 @@ ignore:
   - "/bin"
 
 comment: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
Codecov inline annotations are sometimes annoying during the PR review. To improve the PR review experience this PR disables the Codecov's annotation check.