### PR TITLE
Optimize mustache template detection logic in MinifyHtml transformer

### DIFF
--- a/src/Optimizer/Transformer/MinifyHtml.php
+++ b/src/Optimizer/Transformer/MinifyHtml.php
@@ -32,11 +32,11 @@ final class MinifyHtml implements Transformer
     private $configuration;
 
     /**
-     * Whether the node(s) being minified are inside a mustache template.
+     * Holds the current mustache template depth value.
      *
-     * @var bool
+     * @var int
      */
-    private $isInsideMustacheTemplate = false;
+    private $mustacheTemplateDepth = 0;
 
     /**
      * Instantiate a MinifyHtml object.
@@ -106,8 +106,10 @@ final class MinifyHtml implements Transformer
         }
 
         if ($node->hasChildNodes()) {
-            if ($this->isMustacheTemplate($node)) {
-                $this->isInsideMustacheTemplate = true;
+            $isNodeMustacheTemplate = $this->isMustacheTemplate($node);
+
+            if ($isNodeMustacheTemplate) {
+                $this->mustacheTemplateDepth++;
             }
 
             foreach ($node->childNodes as $childNode) {
@@ -117,8 +119,8 @@ final class MinifyHtml implements Transformer
                 );
             }
 
-            if ($this->isMustacheTemplate($node)) {
-                $this->isInsideMustacheTemplate = false;
+            if ($isNodeMustacheTemplate) {
+                $this->mustacheTemplateDepth--;
             }
         }
 
@@ -177,7 +179,7 @@ final class MinifyHtml implements Transformer
             return [];
         }
 
-        if ($this->isInsideMustacheTemplate && preg_match($this->getMustacheTagPattern(), $node->data)) {
+        if ($this->mustacheTemplateDepth > 0 && preg_match($this->getMustacheTagPattern(), $node->data)) {
             return [];
         }
 


### PR DESCRIPTION
In the MinifyHtml transformer, we are checking twice if the loop is inside a mustache template. This PR fixes this issue by storing the check in a variable. Furthermore, it also handles the situations if we have any nested template element.

Reference: https://github.com/ampproject/amp-toolbox-php/pull/305#discussion_r685472736