### PR TITLE
Fix missing amp binary in the dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,9 @@
 
 # Exclude build & test files from dist archives.
 /.github           export-ignore
-/bin               export-ignore
+/bin/src           export-ignore
+/bin/*.bash        export-ignore
+/bin/*.php         export-ignore
 /tests             export-ignore
 /.editorconfig     export-ignore
 /.gitattributes    export-ignore


### PR DESCRIPTION
In our distributable package archive, the `bin/amp` binary is currently missing, because we are ignoring the whole `bin` directory in `.gitattributes`. This PR fixes that issue by ignoring unnecessary files and directories selectively.

Fixes #308 