### PR TITLE
Allow CSS max byte count enforcement in `TransformedIdentifier` transformer to be configured 

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -915,7 +915,10 @@ final class Document extends DOMDocument
             case 'inlineStyleByteCount':
                 if (!isset($this->inlineStyleByteCount)) {
                     $this->inlineStyleByteCount = 0;
-                    $attributes = $this->xpath->query(self::XPATH_INLINE_STYLE_ATTRIBUTES_QUERY, $this->documentElement);
+                    $attributes = $this->xpath->query(
+                        self::XPATH_INLINE_STYLE_ATTRIBUTES_QUERY,
+                        $this->documentElement
+                    );
                     foreach ($attributes as $attribute) {
                         $this->inlineStyleByteCount += strlen($attribute->textContent);
                     }

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -915,7 +915,7 @@ final class Document extends DOMDocument
             case 'inlineStyleByteCount':
                 if (!isset($this->inlineStyleByteCount)) {
                     $this->inlineStyleByteCount = 0;
-                    $attributes = $this->xpath->query(self::XPATH_INLINE_STYLE_ATTRIBUTES_QUERY, $this->body);
+                    $attributes = $this->xpath->query(self::XPATH_INLINE_STYLE_ATTRIBUTES_QUERY, $this->documentElement);
                     foreach ($attributes as $attribute) {
                         $this->inlineStyleByteCount += strlen($attribute->textContent);
                     }

--- a/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
+++ b/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
@@ -3,11 +3,15 @@
 namespace AmpProject\Optimizer\Configuration;
 
 use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 
 /**
  * Configuration for the TransformedIdentifier transformer.
  *
- * @property int $version Version number to use. Defaults to 0.
+ * @property int $version Version number to use. Defaults to 1.
+ * @property int|false $enforcedCssMaxByteCount The max bytes bytes to enforce on the document, or false to not enforce.
+ *                                              Defaults to max bytes for transformed spec.
  *
  * @package ampproject/amp-toolbox
  */
@@ -22,6 +26,15 @@ final class TransformedIdentifierConfiguration extends BaseTransformerConfigurat
     const VERSION = 'version';
 
     /**
+     * Configuration key that holds the max CSS byte count to enforce.
+     *
+     * @see \AmpProject\Dom\Document::isCssMaxByteCountEnforced()
+     * @see \AmpProject\Dom\Document::enforceCssMaxByteCount()
+     * @var string
+     */
+    const ENFORCED_CSS_MAX_BYTE_COUNT = 'enforcedCssMaxByteCount';
+
+    /**
      * Get the associative array of allowed keys and their respective default values.
      *
      * The array index is the key and the array value is the key's default value.
@@ -31,7 +44,8 @@ final class TransformedIdentifierConfiguration extends BaseTransformerConfigurat
     protected function getAllowedKeys()
     {
         return [
-            self::VERSION => 1,
+            self::VERSION                     => 1,
+            self::ENFORCED_CSS_MAX_BYTE_COUNT => AmpTransformed::SPEC[SpecRule::MAX_BYTES],
         ];
     }
 
@@ -51,6 +65,16 @@ final class TransformedIdentifierConfiguration extends BaseTransformerConfigurat
                         self::class,
                         self::VERSION,
                         'integer',
+                        is_object($value) ? get_class($value) : gettype($value)
+                    );
+                }
+                break;
+            case self::ENFORCED_CSS_MAX_BYTE_COUNT:
+                if (! is_int($value) && $value !== false) {
+                    throw InvalidConfigurationValue::forInvalidSubValueType(
+                        self::class,
+                        self::ENFORCED_CSS_MAX_BYTE_COUNT,
+                        'integer|false',
                         is_object($value) ? get_class($value) : gettype($value)
                     );
                 }

--- a/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
+++ b/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
@@ -10,7 +10,7 @@ use AmpProject\Validator\Spec\SpecRule;
  * Configuration for the TransformedIdentifier transformer.
  *
  * @property int $version Version number to use. Defaults to 1.
- * @property int|false $enforcedCssMaxByteCount The max bytes bytes to enforce on the document, or false to not enforce.
+ * @property int|false $enforcedCssMaxByteCount The max bytes count to enforce on the document, or false to not enforce.
  *                                              Defaults to max bytes for transformed spec.
  *
  * @package ampproject/amp-toolbox

--- a/src/Optimizer/Transformer/TransformedIdentifier.php
+++ b/src/Optimizer/Transformer/TransformedIdentifier.php
@@ -72,7 +72,12 @@ final class TransformedIdentifier implements Transformer
 
         // Ensure that the document uses the larges CSS byte limit for transformed documents,
         // as it would probably be set to the non-transformed limit at this point.
-        $document->enforceCssMaxByteCount(AmpTransformed::SPEC[SpecRule::MAX_BYTES]);
+        $enforced_max_byte_count = $this->configuration->get(
+            TransformedIdentifierConfiguration::ENFORCED_CSS_MAX_BYTE_COUNT
+        );
+        if ($enforced_max_byte_count !== false) {
+            $document->enforceCssMaxByteCount($enforced_max_byte_count);
+        }
     }
 
     /**

--- a/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
+++ b/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
@@ -7,6 +7,8 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
 use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
 use AmpProject\Optimizer\TransformerConfiguration;
 use AmpProject\Tests\TestCase;
+use AmpProject\Validator\Spec\CssRuleset\AmpTransformed;
+use AmpProject\Validator\Spec\SpecRule;
 use stdClass;
 
 /**
@@ -25,20 +27,31 @@ final class TransformedIdentifierConfigurationTest extends TestCase
         $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
         $this->assertEquals(1, $configuration->get('version'));
         $this->assertEquals(1, $configuration->version);
-        $this->assertEquals(['version' => 1], $configuration->toArray());
+        $this->assertEquals(AmpTransformed::SPEC[SpecRule::MAX_BYTES], $configuration->get('enforcedCssMaxByteCount'));
+        $this->assertEquals(AmpTransformed::SPEC[SpecRule::MAX_BYTES], $configuration->enforcedCssMaxByteCount);
+        $this->assertEquals(
+            ['version' => 1, 'enforcedCssMaxByteCount' => AmpTransformed::SPEC[SpecRule::MAX_BYTES]],
+            $configuration->toArray()
+        );
     }
 
     public function testInitialization()
     {
         $configuration = new TransformedIdentifierConfiguration(
             [
-                'version' => 5,
+                'version'                 => 5,
+                'enforcedCssMaxByteCount' => false,
             ]
         );
         $this->assertInstanceOf(TransformerConfiguration::class, $configuration);
         $this->assertEquals(5, $configuration->get('version'));
         $this->assertEquals(5, $configuration->version);
-        $this->assertEquals(['version' => 5], $configuration->toArray());
+        $this->assertEquals(false, $configuration->get('enforcedCssMaxByteCount'));
+        $this->assertEquals(false, $configuration->enforcedCssMaxByteCount);
+        $this->assertEquals(
+            ['version' => 5, 'enforcedCssMaxByteCount' => false],
+            $configuration->toArray()
+        );
     }
 
     public function testThrowsOnInvalidKey()


### PR DESCRIPTION
When working on looser sanitization in the AMP plugin to allow custom CSS larger than what AMP allows, I ran into an issue where an exception was being thrown when the [`AMP_Validation_Manager::update_admin_bar_item()` tries to set a `style` attribute](https://github.com/ampproject/amp-wp/blob/24923a403e6c010228b143375309336509f2eda1/includes/validation/class-amp-validation-manager.php#L1686):

```php
$small = $dom->createElement( 'small' );
$small->setAttribute( 'style', 'font-size: smaller' );
$small->appendChild( $dom->createTextNode( sprintf( '(%s)', $text ) ) );
$validate_link->appendChild( $small );
```

It was throwing a `MaxCssByteCountExceeded` error because my total CSS was over 200KB, and since there was no try/catch around the setting of this attribute it was causing the page to 500.

In the AMP plugin when CSS max size is not being enforced, I want to pass a flag to the `TransformedIdentifier` transformer to skip enforcing CSS max byte count. This PR makes that possible.

Also, this PR fixes a bug with the `Document::$inlineStyleByteCount` magic getter to make sure that any `style` attribute on the `html` element is also accounted for.