### PR TITLE
Add LIBXML_SCHEMA_CREATE flag in Document filter

### DIFF
--- a/src/Dom/Document/Filter/LibxmlCompatibility.php
+++ b/src/Dom/Document/Filter/LibxmlCompatibility.php
@@ -62,8 +62,7 @@ final class LibxmlCompatibility implements BeforeLoadFilter, AfterLoadFilter
         }
 
         /**
-         * This flag prevents removing the closing tags used in inline
-         * JavaScript variables.
+         * This flag prevents removing the closing tags used in inline JavaScript variables.
          */
         if (defined('LIBXML_SCHEMA_CREATE')) {
             $this->options[Option::LIBXML_FLAGS] |= constant('LIBXML_SCHEMA_CREATE');

--- a/src/Dom/Document/Filter/LibxmlCompatibility.php
+++ b/src/Dom/Document/Filter/LibxmlCompatibility.php
@@ -61,9 +61,16 @@ final class LibxmlCompatibility implements BeforeLoadFilter, AfterLoadFilter
             $this->options[Option::LIBXML_FLAGS] |= constant('LIBXML_HTML_NODEFDTD');
         }
 
+        /**
+         * This flag prevents removing the closing tags used in inline
+         * JavaScript variables.
+         */
+        if (defined('LIBXML_SCHEMA_CREATE')) {
+            $this->options[Option::LIBXML_FLAGS] |= constant('LIBXML_SCHEMA_CREATE');
+        }
+
         return $html;
     }
-
 
     /**
      * Process the Document after the html loaded into the Dom\Document.

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -462,6 +462,11 @@ class DocumentTest extends TestCase
                 '<!DOCTYPE html><html amp [class]="mystate.class" class="blue">' . $head . '<body></body></html>',
                 '<!DOCTYPE html><html amp [class]="mystate.class" class="blue">' . $head . '<body></body></html>',
             ],
+            'preserve closing tags in inline js variables' => [
+                'utf-8',
+                '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body><script>let foo = { bar: "<div>amp</div>" }</script></body></html>',
+                '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body><script>let foo = { bar: "<div>amp</div>" }</script></body></html>',
+            ],
         ];
     }
 
@@ -1107,7 +1112,7 @@ class DocumentTest extends TestCase
     {
         $expectedOptions = array_merge(
             Option::DEFAULTS,
-            [Option::ENCODING => 'something', Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD]
+            [Option::ENCODING => 'something', Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_SCHEMA_CREATE]
         );
 
         $document = Document::fromHtml('<html><div></div></html>', [Option::ENCODING => 'something']);
@@ -1130,7 +1135,7 @@ class DocumentTest extends TestCase
     {
         $expectedOptions = array_merge(
             Option::DEFAULTS,
-            [Option::AMP_BIND_SYNTAX => Option::AMP_BIND_SYNTAX_SQUARE_BRACKETS, Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD]
+            [Option::AMP_BIND_SYNTAX => Option::AMP_BIND_SYNTAX_SQUARE_BRACKETS, Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_SCHEMA_CREATE]
         );
 
         $document = Document::fromHtml('<html><div></div></html>', [Option::AMP_BIND_SYNTAX => Option::AMP_BIND_SYNTAX_SQUARE_BRACKETS]);
@@ -1153,7 +1158,7 @@ class DocumentTest extends TestCase
     {
         $expectedOptions = array_merge(
             Option::DEFAULTS,
-            [Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_PARSEHUGE]
+            [Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_SCHEMA_CREATE | LIBXML_PARSEHUGE]
         );
 
         $document = Document::fromHtml('<html><div></div></html>', [Option::LIBXML_FLAGS => LIBXML_PARSEHUGE]);
@@ -1176,7 +1181,7 @@ class DocumentTest extends TestCase
     {
         $expectedOptions = array_merge(
             Option::DEFAULTS,
-            [Option::ENCODING => 'something', Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD]
+            [Option::ENCODING => 'something', Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_SCHEMA_CREATE]
         );
 
         $document = Document::fromHtml('<html><div></div></html>', 'something');
@@ -1197,7 +1202,7 @@ class DocumentTest extends TestCase
     {
         $expectedOptions = array_merge(
             Option::DEFAULTS,
-            [Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_PARSEHUGE]
+            [Option::LIBXML_FLAGS => LIBXML_COMPACT | LIBXML_HTML_NODEFDTD | LIBXML_SCHEMA_CREATE | LIBXML_PARSEHUGE]
         );
 
         $document = new Document();


### PR DESCRIPTION
With our current Document object the closing tags in any inline JS variable stripped out. For example in the following code,
```
<script>
  let foo = {
    bar: '<div>amp</div>',
  };
</script>
``` 
the closing tag in variable **bar** will be removed in the output.
```
<script>
  let foo = {
    bar: '<div>amp',
  };
</script>
``` 

It happens because the core `DOMDocument` class itself removes the tag and throws the warning
```
PHP Warning:  DOMDocument::loadHTML(): Unexpected end tag : div in Entity ...
```

This PR fix this issue using the the `LIBXML_SCHEMA_CREATE` Libxml option provided to the `DOMDocument::loadHTML()`.

Fixes #306 