### PR TITLE
Add randomly-ordered unit test run to GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,12 @@ jobs:
       matrix:
         php: ['8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6']
         coverage: [false]
+        random: [false]
         include:
-          - php: '7.4'
+          - php: '8.0'
             coverage: true
+          - php: '8.0'
+            random: true
 
     steps:
       - name: Checkout
@@ -46,12 +49,16 @@ jobs:
         run: composer install
 
       - name: Run tests
-        if: ${{ matrix.coverage == false }}
+        if: ${{ matrix.random == false && matrix.coverage == false }}
         run: composer unit
 
       - name: Run tests with coverage
-        if: ${{ matrix.coverage == true }}
+        if: ${{ matrix.random == false && matrix.coverage == true }}
         run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Run tests in random order
+        if: ${{ matrix.random == true }}
+        run: vendor/bin/phpunit --order-by random
 
       - name: Upload code coverage report
         if: ${{ matrix.coverage == true }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   unit-test:
-    name: Unit test${{ matrix.coverage && ' (with coverage)' || '' }} / PHP ${{ matrix.php }}
+    name: Unit test${{ matrix.coverage && ' (with coverage)' || '' }}${{ matrix.random && ' (in random order)' || '' }} / PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This avoids running the workflows twice in such a case.

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -128,46 +128,12 @@ class ElementTest extends TestCase
         $element->addInlineStyle('X');
     }
 
-    public function getAddAmpActionData()
-    {
-        $dom    = new Document();
-        $button = $dom->createElementWithAttributes('button', []);
-        $form   = $dom->createElementWithAttributes('form', []);
-
-        return [
-            // Add a toggle class on tap to a button
-            [ $button, 'tap', "some-id.toggleClass(class='some-class')", "tap:some-id.toggleClass(class='some-class')" ],
-            // Add another toggle class on tap to a button
-            [ $button, 'tap', "some-other-id.toggleClass(class='some-class')", "tap:some-id.toggleClass(class='some-class'),some-other-id.toggleClass(class='some-class')" ],
-            // Add a third toggle class on tap to a button
-            [ $button, 'tap', "third-id.toggleClass(class='some-class')", "tap:some-id.toggleClass(class='some-class'),some-other-id.toggleClass(class='some-class'),third-id.toggleClass(class='some-class')" ],
-            // Add some other event to a button
-            [ $button, 'event', 'action', "tap:some-id.toggleClass(class='some-class'),some-other-id.toggleClass(class='some-class'),third-id.toggleClass(class='some-class');event:action" ],
-            // Add another action to the second event to a button
-            [ $button, 'event', 'other-action', "tap:some-id.toggleClass(class='some-class'),some-other-id.toggleClass(class='some-class'),third-id.toggleClass(class='some-class');event:action,other-action" ],
-            // Add fourth action to the tap event to a button
-            [ $button, 'tap', 'lightbox', "tap:some-id.toggleClass(class='some-class'),some-other-id.toggleClass(class='some-class'),third-id.toggleClass(class='some-class'),lightbox;event:action,other-action" ],
-            // Add a submit success action to a form
-            [ $form, 'submit-success', 'success-lightbox', 'submit-success:success-lightbox' ],
-            // Add a submit error action to a form
-            [ $form, 'submit-error', 'error-lightbox', 'submit-success:success-lightbox;submit-error:error-lightbox' ],
-            // Make sure separators within methods won't break
-            [ $dom->createElementWithAttributes('div', [ 'on' => "event:action(method='with problematic characters , : ;')" ]), 'event', "second-action('with problematic characters , : ;')", "event:action(method='with problematic characters , : ;'),second-action('with problematic characters , : ;')" ],
-        ];
-    }
-
     /**
      * Test addAmpAction().
      *
-     * @dataProvider getAddAmpActionData()
      * @covers \AmpProject\Dom\Element::addAmpAction()
-     *
-     * @param Element $element  Element.
-     * @param string     $event    Event.
-     * @param string     $action   Action.
-     * @param string     $expected Expected.
      */
-    public function testAddAmpAction(Element $element, $event, $action, $expected)
+    public function testAddAmpAction()
     {
         $dom    = new Document();
         $button = $dom->createElementWithAttributes('button', []);


### PR DESCRIPTION
This PR adds a single PHPUnit run that is randomly ordered.

This can detect scenarios where the test makes assumptions that are only fulfilled by global state manipulated by a previous test, but are not true in the actual logic to be tested.

In case such a randomly ordered test run fails, the random seed can be found in the GHA log so that this particular ordering can be replicated locally.

Also, to make this work, it also fixes the one test that was dependent on ordering (`Dom\ElementTest::testAddAmpAction`).

/cc @swissspidy 