### PR TITLE
Prepare tests for running in process isolation

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -40,6 +40,11 @@
         <exclude-pattern>src/Validator/Spec/Tag/*_.php</exclude-pattern>
     </rule>
 
+    <!-- Method names for overrides need to stick with their signature independently of the standard. -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/Validator/Spec/Section/*.php</exclude-pattern>
+    </rule>
+
     <!-- WordPress Coding Standards for Inline Documentation and Comments -->
     <rule ref="WordPress-Docs">
         <!-- This does not allow for useful @see and @todo tags with surrounding remarks. -->

--- a/tests/Optimizer/Transformer/TransformedIdentifierTest.php
+++ b/tests/Optimizer/Transformer/TransformedIdentifierTest.php
@@ -28,56 +28,22 @@ final class TransformedIdentifierTest extends TestCase
      */
     public function dataTransform()
     {
-        $input = static function ($html) {
-            return TestMarkup::DOCTYPE . $html . '<head>'
-                   . TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT . TestMarkup::SCRIPT_AMPRUNTIME
-                   . TestMarkup::LINK_FAVICON . TestMarkup::LINK_CANONICAL . TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE
-                   . '</head><body></body></html>';
-        };
-
-        $expected = static function ($html) {
-            return TestMarkup::DOCTYPE . $html . '<head>'
-                   . TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT . TestMarkup::SCRIPT_AMPRUNTIME
-                   . TestMarkup::LINK_FAVICON . TestMarkup::LINK_CANONICAL . TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE
-                   . '</head><body></body></html>';
-        };
-
         return [
             'adds identifier with default version to html tag' => [
-                $input('<html ⚡>'),
-                $expected('<html ⚡ transformed="self;v=1">'),
+                '<html ⚡>',
+                '<html ⚡ transformed="self;v=1">',
             ],
 
             'adds identifier with custom version to html tag' => [
-                $input('<html ⚡>'),
-                $expected('<html ⚡ transformed="self;v=5">'),
+                '<html ⚡>',
+                '<html ⚡ transformed="self;v=5">',
                 [ 'version' => 5 ],
             ],
 
             'adds identifier without version to html tag' => [
-                $input('<html ⚡>'),
-                $expected('<html ⚡ transformed="self">'),
+                '<html ⚡>',
+                '<html ⚡ transformed="self">',
                 [ 'version' => 0 ],
-            ],
-
-            'enforces CSS max byte count by default' => [
-                $input('<html amp style="color:black">'),
-                $expected('<html amp style="color:black" transformed="self;v=1">'),
-                [],
-                function (Document $document) {
-                    $this->assertTrue($document->isCssMaxByteCountEnforced());
-                    $this->assertEquals(AmpTransformed::SPEC[SpecRule::MAX_BYTES] - strlen('color:black'), $document->getRemainingCustomCssSpace());
-                }
-            ],
-
-            'allows skipping enforcement of CSS max byte count' => [
-                $input('<html data-ampdevmode>'),
-                $expected('<html data-ampdevmode transformed="self;v=1">'),
-                [ 'enforcedCssMaxByteCount' => false ],
-                function (Document $document) {
-                    $this->assertFalse($document->isCssMaxByteCountEnforced());
-                    $this->assertEquals(PHP_INT_MAX, $document->getRemainingCustomCssSpace());
-                }
             ],
         ];
     }
@@ -95,15 +61,72 @@ final class TransformedIdentifierTest extends TestCase
      */
     public function testTransform($source, $expectedHtml, $config = [], $assert = null)
     {
-        $document    = Document::fromHtml($source);
+        $document    = Document::fromHtml($this->fullHtml($source));
         $transformer = new TransformedIdentifier(new TransformedIdentifierConfiguration($config));
         $errors      = new ErrorCollection();
 
         $transformer->transform($document, $errors);
 
-        $this->assertEqualMarkup($expectedHtml, $document->saveHTML());
+        $this->assertEqualMarkup($this->fullHtml($expectedHtml), $document->saveHTML());
         if ($assert) {
             $assert($document);
         }
+    }
+
+    /**
+     * @covers \AmpProject\Optimizer\Transformer\TransformedIdentifier::transform()
+     */
+    public function testItEnforcesCssMaxByteCountByDefault()
+    {
+        $document    = Document::fromHtml($this->fullHtml('<html amp style="color:black">'));
+        $transformer = new TransformedIdentifier(new TransformedIdentifierConfiguration([]));
+        $errors      = new ErrorCollection();
+
+        $transformer->transform($document, $errors);
+
+        $this->assertEqualMarkup(
+            $this->fullHtml('<html amp style="color:black" transformed="self;v=1">'),
+            $document->saveHTML()
+        );
+        $this->assertTrue($document->isCssMaxByteCountEnforced());
+        $this->assertEquals(
+            AmpTransformed::SPEC[SpecRule::MAX_BYTES] - strlen('color:black'),
+            $document->getRemainingCustomCssSpace()
+        );
+    }
+
+    /**
+     * @covers \AmpProject\Optimizer\Transformer\TransformedIdentifier::transform()
+     */
+    public function testItAllowsSkippingEnforcementOfCssMaxByteCount()
+    {
+        $document    = Document::fromHtml($this->fullHtml('<html data-ampdevmode>'));
+        $transformer = new TransformedIdentifier(
+            new TransformedIdentifierConfiguration([ 'enforcedCssMaxByteCount' => false ])
+        );
+        $errors      = new ErrorCollection();
+
+        $transformer->transform($document, $errors);
+
+        $this->assertEqualMarkup(
+            $this->fullHtml('<html data-ampdevmode transformed="self;v=1">'),
+            $document->saveHTML()
+        );
+        $this->assertFalse($document->isCssMaxByteCountEnforced());
+        $this->assertEquals(PHP_INT_MAX, $document->getRemainingCustomCssSpace());
+    }
+
+    /**
+     * Get the full HTML document based on the HTML tag to use.
+     *
+     * @param string $html HTML tag to use.
+     * @return string Full HTML document to use.
+     */
+    private function fullHtml($html)
+    {
+        return TestMarkup::DOCTYPE . $html . '<head>'
+               . TestMarkup::META_CHARSET . TestMarkup::META_VIEWPORT . TestMarkup::SCRIPT_AMPRUNTIME
+               . TestMarkup::LINK_FAVICON . TestMarkup::LINK_CANONICAL . TestMarkup::STYLE_AMPBOILERPLATE . TestMarkup::NOSCRIPT_AMPBOILERPLATE
+               . '</head><body></body></html>';
     }
 }

--- a/tests/Validator/Spec/Section/AttributeListsTest.php
+++ b/tests/Validator/Spec/Section/AttributeListsTest.php
@@ -18,10 +18,17 @@ class AttributeListsTest extends TestCase
     /** @var AttributeLists */
     private $attributeLists;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
-        $spec       = new Spec();
+        parent::set_up();
+        $spec                 = new Spec();
         $this->attributeLists = $spec->attributeLists();
     }
 

--- a/tests/Validator/Spec/Section/CssSpecRulesTest.php
+++ b/tests/Validator/Spec/Section/CssSpecRulesTest.php
@@ -19,9 +19,16 @@ class CssSpecRulesTest extends TestCase
     /** @var CssRulesets */
     private $cssRulesets;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
+        parent::set_up();
         $spec              = new Spec();
         $this->cssRulesets = $spec->cssRulesets();
     }

--- a/tests/Validator/Spec/Section/DeclarationListsTest.php
+++ b/tests/Validator/Spec/Section/DeclarationListsTest.php
@@ -17,10 +17,17 @@ class DeclarationListsTest extends TestCase
     /** @var DeclarationLists */
     private $declarationLists;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
-        $spec       = new Spec();
+        parent::set_up();
+        $spec                   = new Spec();
         $this->declarationLists = $spec->declarationLists();
     }
 

--- a/tests/Validator/Spec/Section/DescendantTagListsTest.php
+++ b/tests/Validator/Spec/Section/DescendantTagListsTest.php
@@ -18,9 +18,16 @@ class DescendantTagListsTest extends TestCase
     /** @var DescendantTagLists */
     private $descendantTagLists;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
+        parent::set_up();
         $spec                     = new Spec();
         $this->descendantTagLists = $spec->descendantTagLists();
     }

--- a/tests/Validator/Spec/Section/DocRulesetsTest.php
+++ b/tests/Validator/Spec/Section/DocRulesetsTest.php
@@ -19,9 +19,16 @@ class DocRulesetsTest extends TestCase
     /** @var DocRulesets */
     private $docRulesets;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
+        parent::set_up();
         $spec              = new Spec();
         $this->docRulesets = $spec->docRulesets();
     }

--- a/tests/Validator/Spec/Section/ErrorsTest.php
+++ b/tests/Validator/Spec/Section/ErrorsTest.php
@@ -18,9 +18,16 @@ class ErrorsTest extends TestCase
     /** @var Errors */
     private $errors;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
+        parent::set_up();
         $spec         = new Spec();
         $this->errors = $spec->errors();
     }

--- a/tests/Validator/Spec/Section/TagsTest.php
+++ b/tests/Validator/Spec/Section/TagsTest.php
@@ -2,7 +2,6 @@
 
 namespace AmpProject\Validator\Spec\Section;
 
-use AmpProject\Exception\InvalidExtension;
 use AmpProject\Exception\InvalidFormat;
 use AmpProject\Exception\InvalidSpecName;
 use AmpProject\Extension;
@@ -21,9 +20,16 @@ class TagsTest extends TestCase
     /** @var Tags */
     private $tags;
 
-    public function __construct()
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
+    protected function set_up()
     {
-        parent::__construct();
+        parent::set_up();
         $spec       = new Spec();
         $this->tags = $spec->tags();
     }


### PR DESCRIPTION
While trying to run the tests with the `--process-isolation` flag of PHPUnit, I noticed several problems.

This PR fixes the ones that are obvious changes.

Even with these fixes, though, we cannot run the full test suite in process isolation, as there are multiple errors still. These are due to limitations in how PHPUnit runs the process isolation:
- as data providers are being serialized to pass to the tests, we cannot use `DOMDocument` objects in data providers, as these cannot be serialized;
- as `STDOUT` and `STDERR` are being redirected into temporary memory streams, we cannot use checks like `posix_isatty(STDOUT)`, as these fail on the temporary streams.

/cc @swissspidy