### PR TITLE
Add MinifyHtml to list of default transformers

### DIFF
--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -3,18 +3,6 @@
 namespace AmpProject\Optimizer;
 
 use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
-use AmpProject\Optimizer\Transformer\AmpBoilerplate;
-use AmpProject\Optimizer\Transformer\AmpBoilerplateErrorHandler;
-use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
-use AmpProject\Optimizer\Transformer\AmpRuntimePreloads;
-use AmpProject\Optimizer\Transformer\GoogleFontsPreconnect;
-use AmpProject\Optimizer\Transformer\OptimizeAmpBind;
-use AmpProject\Optimizer\Transformer\OptimizeHeroImages;
-use AmpProject\Optimizer\Transformer\PreloadHeroImage;
-use AmpProject\Optimizer\Transformer\ReorderHead;
-use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
-use AmpProject\Optimizer\Transformer\ServerSideRendering;
-use AmpProject\Optimizer\Transformer\TransformedIdentifier;
 
 /**
  * Interface for a configuration object that validates and stores configuration settings.
@@ -46,17 +34,18 @@ interface Configuration
      * @var string[]
      */
     const DEFAULT_TRANSFORMERS = [
-        TransformedIdentifier::class,
-        AmpBoilerplate::class,
-        OptimizeHeroImages::class,
-        ServerSideRendering::class,
-        AmpRuntimeCss::class,
-        AmpRuntimePreloads::class,
-        AmpBoilerplateErrorHandler::class,
-        GoogleFontsPreconnect::class,
-        RewriteAmpUrls::class,
-        ReorderHead::class,
-        OptimizeAmpBind::class,
+        Transformer\TransformedIdentifier::class,
+        Transformer\AmpBoilerplate::class,
+        Transformer\OptimizeHeroImages::class,
+        Transformer\ServerSideRendering::class,
+        Transformer\AmpRuntimeCss::class,
+        Transformer\AmpRuntimePreloads::class,
+        Transformer\AmpBoilerplateErrorHandler::class,
+        Transformer\GoogleFontsPreconnect::class,
+        Transformer\RewriteAmpUrls::class,
+        Transformer\ReorderHead::class,
+        Transformer\OptimizeAmpBind::class,
+        Transformer\MinifyHtml::class,
     ];
 
     /**

--- a/src/Optimizer/DefaultConfiguration.php
+++ b/src/Optimizer/DefaultConfiguration.php
@@ -2,23 +2,9 @@
 
 namespace AmpProject\Optimizer;
 
-use AmpProject\Optimizer\Configuration\AmpRuntimeCssConfiguration;
-use AmpProject\Optimizer\Configuration\MinifyHtmlConfiguration;
-use AmpProject\Optimizer\Configuration\OptimizeAmpBindConfiguration;
-use AmpProject\Optimizer\Configuration\OptimizeHeroImagesConfiguration;
-use AmpProject\Optimizer\Configuration\PreloadHeroImageConfiguration;
-use AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration;
-use AmpProject\Optimizer\Configuration\TransformedIdentifierConfiguration;
 use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
 use AmpProject\Optimizer\Exception\UnknownConfigurationClass;
 use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
-use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
-use AmpProject\Optimizer\Transformer\MinifyHtml;
-use AmpProject\Optimizer\Transformer\OptimizeAmpBind;
-use AmpProject\Optimizer\Transformer\OptimizeHeroImages;
-use AmpProject\Optimizer\Transformer\PreloadHeroImage;
-use AmpProject\Optimizer\Transformer\RewriteAmpUrls;
-use AmpProject\Optimizer\Transformer\TransformedIdentifier;
 
 /**
  * Configuration object that validates and stores configuration settings.
@@ -45,13 +31,13 @@ class DefaultConfiguration implements Configuration
      * @var array
      */
     protected $transformerConfigurationClasses = [
-        AmpRuntimeCss::class         => AmpRuntimeCssConfiguration::class,
-        OptimizeAmpBind::class       => OptimizeAmpBindConfiguration::class,
-        OptimizeHeroImages::class    => OptimizeHeroImagesConfiguration::class,
-        PreloadHeroImage::class      => PreloadHeroImageConfiguration::class,
-        RewriteAmpUrls::class        => RewriteAmpUrlsConfiguration::class,
-        TransformedIdentifier::class => TransformedIdentifierConfiguration::class,
-        MinifyHtml::class            => MinifyHtmlConfiguration::class,
+        Transformer\AmpRuntimeCss::class         => Configuration\AmpRuntimeCssConfiguration::class,
+        Transformer\OptimizeAmpBind::class       => Configuration\OptimizeAmpBindConfiguration::class,
+        Transformer\OptimizeHeroImages::class    => Configuration\OptimizeHeroImagesConfiguration::class,
+        Transformer\PreloadHeroImage::class      => Configuration\PreloadHeroImageConfiguration::class,
+        Transformer\RewriteAmpUrls::class        => Configuration\RewriteAmpUrlsConfiguration::class,
+        Transformer\TransformedIdentifier::class => Configuration\TransformedIdentifierConfiguration::class,
+        Transformer\MinifyHtml::class            => Configuration\MinifyHtmlConfiguration::class,
     ];
 
     /**


### PR DESCRIPTION
This enables HTML minification by default.

Currently, the `amp-script` minification logic is disabled by default, as it requires an external dependency: `mck89/peast`.