### PR TITLE
Migrate PHPUnit configuration file over to latest schema

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,29 @@
+<?xml version="1.0"?>
 <phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 	bootstrap="vendor/autoload.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	>
+>
+	<coverage processUncoveredFiles="false">
+		<include>
+			<directory suffix=".php">./</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">bin</directory>
+			<directory suffix=".php">resources</directory>
+			<directory suffix=".php">tests</directory>
+			<directory suffix=".php">vendor</directory>
+		</exclude>
+	</coverage>
 	<testsuites>
 		<!-- Default test suite to run all tests -->
 		<testsuite name="default">
-			<directory suffix="Test.php" >./tests/</directory>
+			<directory suffix="Test.php">./tests/</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">./</directory>
-			<exclude>
-				<directory suffix=".php">bin</directory>
-				<directory suffix=".php">resources</directory>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-			</exclude>
-		</whitelist>
-	</filter>
 </phpunit>


### PR DESCRIPTION
This PR migrates the PHPUnit configuration file over to the latest version of the PHPUnit configuration schema (9.3).

This gets rid of the following warning that had been part of the tests runs:

![Image 2021-08-26 at 10 57 33 AM](https://user-images.githubusercontent.com/83631/130935042-6aee6a21-b451-467a-8ae0-502b0fc33b80.jpeg)
