### PR TITLE
Only merge CSS rules for `display:none`

### DIFF
--- a/src/Optimizer/CssRule.php
+++ b/src/Optimizer/CssRule.php
@@ -208,14 +208,20 @@ final class CssRule
      */
     public function canBeMerged(CssRule $that)
     {
+        // As merging rules changes the CSS ordering, it is not a safe operation to do.
+        // Therefore, we hard-code a single scenario here that we want to support (which is the most common case).
+        // This is the only merge that is being done in the Node.js amp-toolbox, so we keep this for consistency
+        // across implementations.
+
         if ($this->mediaQuery !== $that->mediaQuery) {
             return false;
         }
 
-        if (
-            count($this->properties) !== count($that->properties)
-            || array_diff($this->properties, $that->properties)
-        ) {
+        if (count($this->properties) !== 1 || count($that->properties) !== 1) {
+            return false;
+        }
+
+        if ($this->properties[0] !== 'display:none' || $that->properties[0] !== 'display:none') {
             return false;
         }
 

--- a/tests/Optimizer/CssRuleTest.php
+++ b/tests/Optimizer/CssRuleTest.php
@@ -76,33 +76,40 @@ class CssRuleTest extends TestCase
     public function dataCssRuleMerging()
     {
         return [
+            // The only property that should be merged for now is display:none.
+            // Having generic merging in place leads to CSS breakage as the order of execution the CSS moves around.
+
+            'same display:none property' => [['.class1', 'display:none'], ['.class2', 'display:none'], true, ['', ['.class1', '.class2'], ['display:none']]],
+
+            // All of the following rules are testing generic merges, but are currently hard-coded to not be mergeable.
+
             'different single property' => [['.class1', 'color:red'], ['.class2', 'color:blue'], false],
-            'same single property'      => [['.class1', 'color:red'], ['.class2', 'color:red'], true, ['', ['.class1', '.class2'], ['color:red']]],
+            'same single property'      => [['.class1', 'color:red'], ['.class2', 'color:red'], false],
 
             'different multiple properties' => [['.class1', 'color:red;background-color:green'], ['.class2', 'color:red;background-color:blue'], false],
-            'same multiple properties'      => [['.class1', 'color:red;background-color:green'], ['.class2', 'color:red;background-color:green'], true, ['', ['.class1', '.class2'], ['background-color:green', 'color:red']]],
+            'same multiple properties'      => [['.class1', 'color:red;background-color:green'], ['.class2', 'color:red;background-color:green'], false],
 
             'multiple selectors with different single property' => [['.class1,.class2', 'color:red'], ['.class3,.class4', 'color:blue'], false],
-            'multiple selectors with same single property'      => [['.class1,.class2', 'color:red'], ['.class3,.class4', 'color:red'], true, ['', ['.class1', '.class2', '.class3', '.class4'], ['color:red']]],
+            'multiple selectors with same single property'      => [['.class1,.class2', 'color:red'], ['.class3,.class4', 'color:red'], false],
 
             'multiple selectors with different multiple properties' => [['.class1,.class2', 'color:red;background-color:green'], ['.class3,.class4', 'color:red;background-color:blue'], false],
-            'multiple selectors with same multiple properties'      => [['.class1,.class2', 'color:red;background-color:green'], ['.class3,.class4', 'color:red;background-color:green'], true, ['', ['.class1', '.class2', '.class3', '.class4'], ['background-color:green', 'color:red']]],
+            'multiple selectors with same multiple properties'      => [['.class1,.class2', 'color:red;background-color:green'], ['.class3,.class4', 'color:red;background-color:green'], false],
 
-            'overlap in selectors' => [['.class1,.class2', 'color:red'], ['.class2,.class3', 'color:red'], true, ['', ['.class1', '.class2', '.class3'], ['color:red']]],
+            'overlap in selectors' => [['.class1,.class2', 'color:red'], ['.class2,.class3', 'color:red'], false],
 
             'same media query - different single property' => [['@media not all and (min-width: 650px)', '.class1', 'color:red'], ['@media not all and (min-width: 650px)', '.class2', 'color:blue'], false],
-            'same media query - same single property'      => [['@media not all and (min-width: 650px)', '.class1', 'color:red'], ['@media not all and (min-width: 650px)', '.class2', 'color:red'], true, ['@media not all and (min-width: 650px)', ['.class1', '.class2'], ['color:red']]],
+            'same media query - same single property'      => [['@media not all and (min-width: 650px)', '.class1', 'color:red'], ['@media not all and (min-width: 650px)', '.class2', 'color:red'], false],
 
             'same media query - different multiple properties' => [['@media not all and (min-width: 650px)', '.class1', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class2', 'color:red;background-color:blue'], false],
-            'same media query - same multiple properties'      => [['@media not all and (min-width: 650px)', '.class1', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class2', 'color:red;background-color:green'], true, ['@media not all and (min-width: 650px)', ['.class1', '.class2'], ['background-color:green', 'color:red']]],
+            'same media query - same multiple properties'      => [['@media not all and (min-width: 650px)', '.class1', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class2', 'color:red;background-color:green'], false],
 
             'same media query - multiple selectors with different single property' => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:blue'], false],
-            'same media query - multiple selectors with same single property'      => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:red'], true, ['@media not all and (min-width: 650px)', ['.class1', '.class2', '.class3', '.class4'], ['color:red']]],
+            'same media query - multiple selectors with same single property'      => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:red'], false],
 
             'same media query - multiple selectors with different multiple properties' => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:red;background-color:blue'], false],
-            'same media query - multiple selectors with same multiple properties'      => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:red;background-color:green'], true, ['@media not all and (min-width: 650px)', ['.class1', '.class2', '.class3', '.class4'], ['background-color:green', 'color:red']]],
+            'same media query - multiple selectors with same multiple properties'      => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red;background-color:green'], ['@media not all and (min-width: 650px)', '.class3,.class4', 'color:red;background-color:green'], false],
 
-            'same media query - overlap in selectors' => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red'], ['@media not all and (min-width: 650px)', '.class2,.class3', 'color:red'], true, ['@media not all and (min-width: 650px)', ['.class1', '.class2', '.class3'], ['color:red']]],
+            'same media query - overlap in selectors' => [['@media not all and (min-width: 650px)', '.class1,.class2', 'color:red'], ['@media not all and (min-width: 650px)', '.class2,.class3', 'color:red'], false],
 
             'different media query - different single property' => [['@media not all and (min-width: 650px)', '.class1', 'color:red'], ['@media not all and (min-width: 950px)', '.class2', 'color:blue'], false],
             'different media query - same single property'      => [['@media not all and (min-width: 650px)', '.class1', 'color:red'], ['@media not all and (min-width: 950px)', '.class2', 'color:red'], false],

--- a/tests/Optimizer/CssRulesTest.php
+++ b/tests/Optimizer/CssRulesTest.php
@@ -58,7 +58,7 @@ class CssRulesTest extends TestCase
             ->add(new CssRule('h3', 'color:red'))
             ->add(new CssRule('h4', 'color:green'))
             ->add(new CssRule('h5', 'color:red'));
-        $this->assertEquals('h1,h3,h5{color:red}h2,h4{color:green}', $cssRules->getCss());
+        $this->assertEquals('h1{color:red}h2{color:green}h3{color:red}h4{color:green}h5{color:red}', $cssRules->getCss());
     }
 
     /**
@@ -76,6 +76,6 @@ class CssRulesTest extends TestCase
                 new CssRule('h5', 'color:red'),
             ]
         );
-        $this->assertEquals('h1,h3,h5{color:red}h2,h4{color:green}', $cssRules->getCss());
+        $this->assertEquals('h1{color:red}h2{color:green}h3{color:red}h4{color:green}h5{color:red}', $cssRules->getCss());
     }
 }


### PR DESCRIPTION
We have implemented CSS selector merging to save some bytes against the CSS byte limit. However, merging CSS rules causes CSS breakage in some cases, as CSS is dependent on execution order.

As an example, consider the following CSS:
```css
.a { color: green; }
.b { color: red; }
.b { color: green; }
```
Both `.a` and `.b` will appear green.

If we merge selectors that have the same properties, we end up with the following:
```css
.a, .b { color: green; }
.b { color: red; }
```
Now, `.a` will still appear green, but `.b` all of a sudden turned red.

This PR disables CSS selector merging in general, as it is not safe and it would be too complex to implement a more robust mechanism.

However, it keeps a single hard-code scenario enabled, to keep in sync with the Node.js toolbox. It merges the selectors if the only property is `display:none`. This is needed so that the synced spec tests still pass. The relevant code in the Node.js toolbox can be found here: https://github.com/ampproject/amp-toolbox/blob/3.0.0-canary.1/packages/optimizer/lib/transformers/ApplyCommonAttributes.js#L65

Resolves #333 