### PR TITLE
Add ProtectEsiTags Document filter

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -202,6 +202,7 @@ final class Document extends DOMDocument
                 Filter\DocumentEncoding::class,
                 Filter\HttpEquivCharset::class,
                 Filter\LibxmlCompatibility::class,
+                Filter\ProtectEsiTags::class,
             ]
         );
     }

--- a/src/Dom/Document/Filter/ProtectEsiTags.php
+++ b/src/Dom/Document/Filter/ProtectEsiTags.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AmpProject\Dom\Document\Filter;
+
+use AmpProject\Dom\Document\AfterSaveFilter;
+use AmpProject\Dom\Document\BeforeLoadFilter;
+
+/**
+ * Protect the esi tags from being broken.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class ProtectEsiTags implements BeforeLoadFilter, AfterSaveFilter
+{
+
+    /**
+     * List of self closing ESI tags.
+     *
+     * @link https://www.w3.org/TR/esi-lang/
+     *
+     * @var string[]
+     */
+    const SELF_CLOSING_TAGS = [
+        'esi:include',
+        'esi:comment',
+    ];
+
+    /**
+     * Preprocess the HTML to be loaded into the Dom\Document.
+     *
+     * @param string $html String of HTML markup to be preprocessed.
+     * @return string Preprocessed string of HTML markup.
+     */
+    public function beforeLoad($html)
+    {
+        $selfClosingregex = '#<(' . implode('|', self::SELF_CLOSING_TAGS) . ')([^>]*?)(?>\s*(?<!\\\\)/)?>(?!</\1>)#';
+
+        $html = preg_replace($selfClosingregex, '<$1$2></$1>', $html);
+        $html = preg_replace('/(<esi:include.+?)(src)=/', '$1esi-src=', $html);
+        $html = preg_replace('/(<\/?)esi:/', '$1esi-', $html);
+
+        return $html;
+    }
+
+    /**
+     * Process the Dom\Document after being saved from Dom\Document.
+     *
+     * @param string $html String of HTML markup to be preprocessed.
+     * @return string Preprocessed string of HTML markup.
+     */
+    public function afterSave($html)
+    {
+        $selfClosingregex = '#</(' . implode('|', self::SELF_CLOSING_TAGS) . ')>#i';
+
+        $html = preg_replace('/(<\/?)esi-/', '$1esi:', $html);
+        $html = preg_replace('/(<esi:include.+?)(esi-src)=/', '$1src=', $html);
+        $html = preg_replace($selfClosingregex, '', $html);
+
+        return $html;
+    }
+}

--- a/src/Dom/Document/Filter/ProtectEsiTags.php
+++ b/src/Dom/Document/Filter/ProtectEsiTags.php
@@ -50,11 +50,11 @@ final class ProtectEsiTags implements BeforeLoadFilter, AfterSaveFilter
      */
     public function afterSave($html)
     {
-        $selfClosingregex = '#</(' . implode('|', self::SELF_CLOSING_TAGS) . ')>#i';
+        $selfClosingregex = '#></(' . implode('|', self::SELF_CLOSING_TAGS) . ')>#i';
 
         $html = preg_replace('/(<\/?)esi-/', '$1esi:', $html);
         $html = preg_replace('/(<esi:include.+?)(esi-src)=/', '$1src=', $html);
-        $html = preg_replace($selfClosingregex, '', $html);
+        $html = preg_replace($selfClosingregex, '/>', $html);
 
         return $html;
     }

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -482,10 +482,10 @@ class DocumentTest extends TestCase
                 '<!DOCTYPE html><html>' . $head . '<body>'
                 . '    <esi:choose>'
                 . '        <esi:when test="$(logindata{name}) == null">'
-                . '            <esi:include src="/login/$(logindata{name})">'
+                . '            <esi:include src="/login/$(logindata{name})"/>'
                 . '        </esi:when>'
                 . '        <esi:otherwise>'
-                . '            <esi:include src="/login/guest.html">'
+                . '            <esi:include src="/login/guest.html"/>'
                 . '        </esi:otherwise>'
                 . '    </esi:choose>'
                 . '</body></html>',

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -467,6 +467,29 @@ class DocumentTest extends TestCase
                 '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body><script>let foo = { bar: "<div>amp</div>" }</script></body></html>',
                 '<!DOCTYPE html><html amp data-text="⚡">' . $head . '<body><script>let foo = { bar: "<div>amp</div>" }</script></body></html>',
             ],
+            'preserve Varnish esi tags' => [
+                'utf-8',
+                '<!DOCTYPE html><html><head></head><body>'
+                . '    <esi:choose>'
+                . '        <esi:when test="$(logindata{name}) == null">'
+                . '            <esi:include src="/login/$(logindata{name})"/>'
+                . '        </esi:when>'
+                . '        <esi:otherwise>'
+                . '            <esi:include src="/login/guest.html"/>'
+                . '        </esi:otherwise>'
+                . '    </esi:choose>'
+                . '</body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body>'
+                . '    <esi:choose>'
+                . '        <esi:when test="$(logindata{name}) == null">'
+                . '            <esi:include src="/login/$(logindata{name})">'
+                . '        </esi:when>'
+                . '        <esi:otherwise>'
+                . '            <esi:include src="/login/guest.html">'
+                . '        </esi:otherwise>'
+                . '    </esi:choose>'
+                . '</body></html>',
+            ]
         ];
     }
 


### PR DESCRIPTION
The PHP DOMDocument alters the [ESI tags](https://www.w3.org/TR/esi-lang/) that use colon in the tag and remove the `esi:` part and hence breaks the system. This PR adds a new Document filter to fix this issue.

Fixes #202