### PR TITLE
Add `$headers` argument to `RemoteGetRequest::get()`

### DIFF
--- a/src/RemoteGetRequest.php
+++ b/src/RemoteGetRequest.php
@@ -17,9 +17,10 @@ interface RemoteGetRequest
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *
-     * @param string $url URL to get.
+     * @param string $url     URL to get.
+     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
      * @return Response Response for the executed request.
      * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
      */
-    public function get($url);
+    public function get($url, $headers = []);
 }

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -91,16 +91,16 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *
-     * @param string $url URL to get.
+     * @param string $url     URL to get.
+     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
      * @return Response Response for the executed request.
      * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
      */
-    public function get($url)
+    public function get($url, $headers = [])
     {
         $retriesLeft = $this->retries;
         do {
             $curlHandle = curl_init();
-            $headers    = [];
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
             curl_setopt($curlHandle, CURLOPT_HEADER, 0);

--- a/src/RemoteRequest/FallbackRemoteGetRequest.php
+++ b/src/RemoteRequest/FallbackRemoteGetRequest.php
@@ -53,15 +53,16 @@ final class FallbackRemoteGetRequest implements RemoteGetRequest
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *
-     * @param string $url URL to get.
+     * @param string $url     URL to get.
+     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
      * @return Response Response for the executed request.
      * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
      */
-    public function get($url)
+    public function get($url, $headers = [])
     {
         foreach ($this->pipeline as $remoteGetRequest) {
             try {
-                $response = $remoteGetRequest->get($url);
+                $response = $remoteGetRequest->get($url, $headers);
 
                 if (! $response instanceof RemoteGetRequestResponse) {
                     continue;

--- a/src/RemoteRequest/FilesystemRemoteGetRequest.php
+++ b/src/RemoteRequest/FilesystemRemoteGetRequest.php
@@ -39,12 +39,13 @@ final class FilesystemRemoteGetRequest implements RemoteGetRequest
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *
-     * @param string $url URL to get.
+     * @param string $url     URL to get.
+     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
      * @return Response Response for the executed request.
      * @throws FailedToGetFromRemoteUrl If retrieving the contents from the URL failed.
      * @throws LogicException If invalid file path and/or invalid or non-readable file.
      */
-    public function get($url)
+    public function get($url, $headers = [])
     {
         if (! array_key_exists($url, $this->argumentMap)) {
             throw new LogicException("Trying to get a remote request from the filesystem for an unknown URL: {$url}.");

--- a/src/RemoteRequest/StubbedRemoteGetRequest.php
+++ b/src/RemoteRequest/StubbedRemoteGetRequest.php
@@ -35,11 +35,12 @@ final class StubbedRemoteGetRequest implements RemoteGetRequest
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *
-     * @param string $url URL to get.
+     * @param string $url     URL to get.
+     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
      * @return Response Response for the executed request.
      * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
      */
-    public function get($url)
+    public function get($url, $headers = [])
     {
         if (! array_key_exists($url, $this->argumentMap)) {
             throw new LogicException("Trying to stub a remote request for an unknown URL: {$url}.");

--- a/tests/RemoteRequest/FallbackRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/FallbackRemoteGetRequestTest.php
@@ -19,24 +19,24 @@ class FallbackRemoteGetRequestTest extends TestCase
         $fallbackRequest1 = $this->createMock(RemoteGetRequest::class);
         $fallbackRequest1->method('get')->willReturnMap(
             [
-                ['file 1', new RemoteGetRequestResponse('data-1-1', [], 200)],
+                ['file 1', [], new RemoteGetRequestResponse('data-1-1', [], 200)],
             ]
         );
 
         $fallbackRequest2 = $this->createMock(RemoteGetRequest::class);
         $fallbackRequest2->method('get')->willReturnMap(
             [
-                ['file 1', new RemoteGetRequestResponse('data-2-1', [], 200)],
-                ['file 2', new RemoteGetRequestResponse('data-2-2', [], 200)],
+                ['file 1', [], new RemoteGetRequestResponse('data-2-1', [], 200)],
+                ['file 2', [], new RemoteGetRequestResponse('data-2-2', [], 200)],
             ]
         );
 
         $fallbackRequest3 = $this->createMock(RemoteGetRequest::class);
         $fallbackRequest3->method('get')->willReturnMap(
             [
-                ['file 1', new RemoteGetRequestResponse('data-3-1', [], 200)],
-                ['file 2', new RemoteGetRequestResponse('data-3-2', [], 200)],
-                ['file 3', new RemoteGetRequestResponse('data-3-3', [], 200)],
+                ['file 1', [], new RemoteGetRequestResponse('data-3-1', [], 200)],
+                ['file 2', [], new RemoteGetRequestResponse('data-3-2', [], 200)],
+                ['file 3', [], new RemoteGetRequestResponse('data-3-3', [], 200)],
             ]
         );
 
@@ -58,31 +58,31 @@ class FallbackRemoteGetRequestTest extends TestCase
 
         $response = $request->get('file 1');
         $this->assertInstanceOf(RemoteGetRequestResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode(), 'file 1 request failed');
         $this->assertEmpty($response->getHeaders());
         $this->assertEquals('data-1-1', $response->getBody());
 
         $response = $request->get('file 2');
         $this->assertInstanceOf(RemoteGetRequestResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode(), 'file 2 request failed');
         $this->assertEmpty($response->getHeaders());
         $this->assertEquals('data-2-2', $response->getBody());
 
         $response = $request->get('file 3');
         $this->assertInstanceOf(RemoteGetRequestResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(200, $response->getStatusCode(), 'file 3 request failed');
         $this->assertEmpty($response->getHeaders());
         $this->assertEquals('data-3-3', $response->getBody());
 
         $response = $request->get('unknown file');
         $this->assertInstanceOf(RemoteGetRequestResponse::class, $response);
-        $this->assertEquals(503, $response->getStatusCode());
+        $this->assertEquals(503, $response->getStatusCode(), 'unknown file request was supposed to fail');
         $this->assertEmpty($response->getHeaders());
         $this->assertEquals('', $response->getBody());
 
         $response = $request->get('throw exception');
         $this->assertInstanceOf(RemoteGetRequestResponse::class, $response);
-        $this->assertEquals(503, $response->getStatusCode());
+        $this->assertEquals(503, $response->getStatusCode(), 'exception was supposed to fail');
         $this->assertEmpty($response->getHeaders());
         $this->assertEquals('', $response->getBody());
     }


### PR DESCRIPTION
This PR adds a second optional argument `$headers` to the `RemoteGetRequest::get()` signature.

This is currently needed for adding a referrer to PSI API requests in `ampproject/px-toolbox-php`.

### Breaking Change

This is a breaking change for all consumers that extend the `RemoteGetRequest` interface to provide their own implementation.

**Signature before:**
```php
    /**
     * Do a GET request to retrieve the contents of a remote URL.
     *
     * @param string $url URL to get.
     * @return Response Response for the executed request.
     * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
     */
    public function get($url);
```

***Signature after:***
```php
    /**
     * Do a GET request to retrieve the contents of a remote URL.
     *
     * @param string $url     URL to get.
     * @param array  $headers Optional. Associative array of headers to send with the request. Defaults to empty array.
     * @return Response Response for the executed request.
     * @throws FailedRemoteRequest If retrieving the contents from the URL failed.
     */
    public function get($url, $headers = []);
```