### PR TITLE
Refactor CLI option retrieval to improve typing

### DIFF
--- a/src/Cli/Options.php
+++ b/src/Cli/Options.php
@@ -355,21 +355,32 @@ class Options
      *
      * Can only be used after parseOptions() has been run.
      *
-     * @param mixed       $option  Optional. Option to get. Use null to get all options (default).
+     * @param string      $option  Option to get.
      * @param bool|string $default Optional. Default value to return if the option is not set. Defaults to false.
-     * @return bool|string|string[] Value of the option.
+     * @return bool|string Value of the option.
      */
-    public function getOption($option = null, $default = false)
+    public function getOption($option, $default = false)
     {
-        if ($option === null) {
-            return $this->options;
-        }
-
         if (isset($this->options[$option])) {
             return $this->options[$option];
         }
 
         return $default;
+    }
+
+    /**
+     * Get all options.
+     *
+     * Please note that all options are accessed by their long option names regardless of how they were
+     * specified on commandline.
+     *
+     * Can only be used after parseOptions() has been run.
+     *
+     * @return string[] Associative array of all options.
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**

--- a/tests/Cli/OptionsTest.php
+++ b/tests/Cli/OptionsTest.php
@@ -260,7 +260,7 @@ class OptionsTest extends TestCase
         $this->assertEquals('something', $options->getOption('fourth'));
         $this->assertEquals(true, $options->getOption('fifth'));
         $this->assertEquals(false, $options->getOption('sixth'));
-        $this->assertEquals(['fourth' => 'something', 'fifth' => true], $options->getOption());
+        $this->assertEquals(['fourth' => 'something', 'fifth' => true], $options->getOptions());
     }
 
     public function testCheckArgumentsThrowsOnArgumentNumberMismatch()


### PR DESCRIPTION
This PR splits the `Options::getOption($option = [], $default = false)` method up into two separate methods:
- `Options::getOption($option, $default = false)` to retrieve the value of a single option.
- `Options::getOptions()` to retrieve an associative array of all options.

This solves a static analysis problem where the return value can be an array or a scalar.