### PR TITLE
Fix outdated PHPStan version in GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, iconv, json, libxml, zip
-          tools: composer, cs2pr
+          tools: composer, cs2pr, phpstan
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -146,5 +146,5 @@ jobs:
       - name: Static Analysis (PHPStan)
         if: ${{ matrix.php != '5.6' && matrix.php != '7.0' }}
         run: |
-          vendor/bin/phpstan --version
-          vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
+          phpstan --version
+          phpstan analyse --error-format=checkstyle | cs2pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,4 +145,6 @@ jobs:
 
       - name: Static Analysis (PHPStan)
         if: ${{ matrix.php != '5.6' && matrix.php != '7.0' }}
-        run: vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
+        run: |
+          vendor/bin/phpstan --version
+          vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr


### PR DESCRIPTION
We are seeing repeated issues with caching of the PHPStan executable. The GHA cache cannot be invalidated, so the download for the PHPStan binary is sometimes stale for an undetermined time period.

This PR changes the workflow to use PHPStan as a Setup-PHP action tool, instead of from the Composer binary in the cache. The Composer binary is still left as a test dependency for local setups.

For easier debugging, this PR also outputs the version of PHPStan being used before running the analysis.