### PR TITLE
Fix logic for converting the attribute value to string

### DIFF
--- a/src/Dom/Element.php
+++ b/src/Dom/Element.php
@@ -73,7 +73,7 @@ final class Element extends DOMElement
     public function setAttribute($name, $value)
     {
         // Make sure $value is always a string and not null.
-        $value = $value ? $value : '';
+        $value = strval($value);
 
         if (
             $name === Attribute::STYLE

--- a/tests/Dom/ElementTest.php
+++ b/tests/Dom/ElementTest.php
@@ -480,4 +480,37 @@ class ElementTest extends TestCase
             $this->assertEquals($attributes[ $name ], $value, sprintf('Attribute "%s" does not have expected value.', $name));
         }
     }
+
+    /**
+     * Test setAttribute should always use string type attribute value.
+     */
+    public function testSetAttributeVShouldAlwaysUseStringValue()
+    {
+        $dom        = Document::fromHtml('<p>Hello World</p>');
+        $element    = $dom->createElement('div');
+        $attributes = [
+            'data-attr-string'        => 'string',
+            'data-attr-string-falsy'  => '0',
+            'data-attr-integer'       => 1,
+            'data-attr-integer-falsy' => 0,
+            'data-attr-float'         => 1.01,
+            'data-attr-float-falsy'   => 0.0,
+            'data-attr-null-attr'     => null,
+            'data-attr-boolean-true'  => true,
+            'data-attr-boolean-false' => false,
+
+        ];
+
+        $element->setAttributes($attributes);
+
+        $this->assertEquals('string', $element->getAttribute('data-attr-string'));
+        $this->assertEquals('0', $element->getAttribute('data-attr-string-falsy'));
+        $this->assertEquals('1', $element->getAttribute('data-attr-integer'));
+        $this->assertEquals('0', $element->getAttribute('data-attr-integer-falsy'));
+        $this->assertEquals('1.01', $element->getAttribute('data-attr-float'));
+        $this->assertEquals('0', $element->getAttribute('data-attr-float-falsy'));
+        $this->assertEquals('', $element->getAttribute('data-attr-null-attr'));
+        $this->assertEquals('1', $element->getAttribute('data-attr-boolean-true'));
+        $this->assertEquals('', $element->getAttribute('data-attr-boolean-false'));
+    }
 }


### PR DESCRIPTION
This PR fixes the issue when we try to set an attribute value `'0'`, for example 
```$element->setAttribute('tabindex', '0')```

Also added some related tests to make sure we always use the string value of the attribute value.