### PR TITLE
Fix OptimizeViewport order in optimizer configuration

### DIFF
--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -43,9 +43,9 @@ interface Configuration
         Transformer\AmpBoilerplateErrorHandler::class,
         Transformer\GoogleFontsPreconnect::class,
         Transformer\RewriteAmpUrls::class,
+        Transformer\OptimizeViewport::class,
         Transformer\ReorderHead::class,
         Transformer\OptimizeAmpBind::class,
-        Transformer\OptimizeViewport::class,
         Transformer\MinifyHtml::class,
     ];
 

--- a/tests/Optimizer/TransformationEngineTest.php
+++ b/tests/Optimizer/TransformationEngineTest.php
@@ -25,8 +25,8 @@ final class TransformationEngineTest extends TestCase
     const MINIMAL_OPTIMIZED_HTML_MARKUP = TestMarkup::DOCTYPE .
                                           '<html transformed="self;v=1" i-amphtml-layout="" i-amphtml-no-boilerplate=""><head>' .
                                           TestMarkup::META_CHARSET .
-                                          '<style amp-runtime="" i-amphtml-version="012345678900000">/* v0.css */</style>' .
                                           '<meta name="viewport" content="width=device-width">' .
+                                          '<style amp-runtime="" i-amphtml-version="012345678900000">/* v0.css */</style>' .
                                           '</head><body></body></html>';
 
     /**


### PR DESCRIPTION
This PR fixes the execution order issue of OptimizeViewport transformer. OptimizeViewport transformer should execute before ReorderHead transformer, so that we can have the viewport meta at top and not bottom in the head tag.

Related to https://github.com/ampproject/amp-wp/pull/6657#discussion_r736776023. 