### PR TITLE
Disable whitespace collapsing by default in `MinifyHtml` transformer

### DIFF
--- a/src/Optimizer/Configuration/MinifyHtmlConfiguration.php
+++ b/src/Optimizer/Configuration/MinifyHtmlConfiguration.php
@@ -76,7 +76,7 @@ final class MinifyHtmlConfiguration extends BaseTransformerConfiguration
             self::MINIFY                  => true,
             self::MINIFY_AMP_SCRIPT       => false,
             self::MINIFY_JSON             => true,
-            self::COLLAPSE_WHITESPACE     => true,
+            self::COLLAPSE_WHITESPACE     => false,
             self::REMOVE_COMMENTS         => true,
             self::COMMENT_IGNORE_PATTERN  => '',
         ];

--- a/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
+++ b/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
@@ -85,6 +85,7 @@ final class TemporaryFileCachedRemoteGetRequest implements RemoteGetRequest
 
         $cachedResponse = file_get_contents($file);
 
+        // phpcs:disable PHPCompatibility.FunctionUse.NewFunctionParameters.unserialize_optionsFound
         if ($cachedResponse !== false) {
             if (PHP_MAJOR_VERSION >= 7) {
                 $cachedResponse = unserialize($cachedResponse, [RemoteGetRequestResponse::class]);
@@ -93,6 +94,7 @@ final class TemporaryFileCachedRemoteGetRequest implements RemoteGetRequest
                 $cachedResponse = unserialize($cachedResponse);
             }
         }
+        // phpcs:enable PHPCompatibility.FunctionUse.NewFunctionParameters.unserialize_optionsFound
 
         if (! $cachedResponse instanceof RemoteGetRequestResponse || $this->isExpired($file, $cachedResponse)) {
             return $this->getRemoteResponse($url, $headers);

--- a/tests/Optimizer/Configuration/MinifyHtmlConfigurationTest.php
+++ b/tests/Optimizer/Configuration/MinifyHtmlConfigurationTest.php
@@ -29,8 +29,8 @@ final class MinifyHtmlConfigurationTest extends TestCase
         $this->assertEquals(false, $configuration->minifyAmpScript);
         $this->assertEquals(true, $configuration->get('minifyJSON'));
         $this->assertEquals(true, $configuration->minifyJSON);
-        $this->assertEquals(true, $configuration->get('collapseWhitespace'));
-        $this->assertEquals(true, $configuration->collapseWhitespace);
+        $this->assertEquals(false, $configuration->get('collapseWhitespace'));
+        $this->assertEquals(false, $configuration->collapseWhitespace);
         $this->assertEquals(true, $configuration->get('removeComments'));
         $this->assertEquals(true, $configuration->removeComments);
         $this->assertEquals('', $configuration->get('commentIgnorePattern'));
@@ -40,7 +40,7 @@ final class MinifyHtmlConfigurationTest extends TestCase
                 'minify'                => true,
                 'minifyAmpScript'       => false,
                 'minifyJSON'            => true,
-                'collapseWhitespace'    => true,
+                'collapseWhitespace'    => false,
                 'removeComments'        => true,
                 'commentIgnorePattern'  => '',
             ],
@@ -54,7 +54,7 @@ final class MinifyHtmlConfigurationTest extends TestCase
             'minify'                => false,
             'minifyAmpScript'       => true,
             'minifyJSON'            => false,
-            'collapseWhitespace'    => false,
+            'collapseWhitespace'    => true,
             'removeComments'        => false,
             'commentIgnorePattern'  => '/^\s*__[a-b]+__\s*$/',
         ]);
@@ -65,8 +65,8 @@ final class MinifyHtmlConfigurationTest extends TestCase
         $this->assertEquals(true, $configuration->minifyAmpScript);
         $this->assertEquals(false, $configuration->get('minifyJSON'));
         $this->assertEquals(false, $configuration->minifyJSON);
-        $this->assertEquals(false, $configuration->get('collapseWhitespace'));
-        $this->assertEquals(false, $configuration->collapseWhitespace);
+        $this->assertEquals(true, $configuration->get('collapseWhitespace'));
+        $this->assertEquals(true, $configuration->collapseWhitespace);
         $this->assertEquals(false, $configuration->get('removeComments'));
         $this->assertEquals(false, $configuration->removeComments);
         $this->assertEquals('/^\s*__[a-b]+__\s*$/', $configuration->get('commentIgnorePattern'));
@@ -76,7 +76,7 @@ final class MinifyHtmlConfigurationTest extends TestCase
                 'minify'                => false,
                 'minifyAmpScript'       => true,
                 'minifyJSON'            => false,
-                'collapseWhitespace'    => false,
+                'collapseWhitespace'    => true,
                 'removeComments'        => false,
                 'commentIgnorePattern'  => '/^\s*__[a-b]+__\s*$/',
             ],


### PR DESCRIPTION
Fixes #427 