### PR TITLE
Add compatibility fix to alias moved classes

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -13,6 +13,7 @@
 
     <!-- Include only the directories containing PHP files. -->
     <file>bin/</file>
+    <file>include/</file>
     <file>src/</file>
     <file>tests/</file>
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,10 @@
   "autoload": {
     "psr-4": {
       "AmpProject\\": "src/"
-    }
+    },
+    "files": [
+      "include/compatibility-fixes.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/include/compatibility-fixes.php
+++ b/include/compatibility-fixes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AmpProject;
+
+/**
+ * @var array<class-string<CompatibilityFix>> $compatibilityFixes
+ */
+$compatibilityFixes = [
+    CompatibilityFix\MovedClasses::class,
+];
+
+foreach ($compatibilityFixes as $compatibilityFix) {
+    $compatibilityFix::register();
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ parameters:
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true
 	paths:
+		- include/
 		- src/
 	ignoreErrors:
 		- '#^Unsafe usage of new static\(\).$#'

--- a/src/CompatibilityFix.php
+++ b/src/CompatibilityFix.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AmpProject;
+
+/**
+ * Compatibility fix that can be registered.
+ *
+ * @package ampproject/amp-toolbox
+ */
+interface CompatibilityFix
+{
+
+    /**
+     * Register the compatibility fix.
+     *
+     * @return void
+     */
+    public static function register();
+}

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -38,12 +38,16 @@ final class MovedClasses implements CompatibilityFix
      */
     public static function register()
     {
-        foreach (self::ALIASES as $old => $new) {
-            if (class_exists($old)) {
-                continue;
-            }
+        spl_autoload_register(
+            static function ($oldClassName) {
+                if (! array_key_exists($oldClassName, self::ALIASES)) {
+                    return false;
+                }
 
-            class_alias($new, $old, true);
-        }
+                class_alias(self::ALIASES[$oldClassName], $oldClassName, true);
+
+                return true;
+            }
+        );
     }
 }

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -38,16 +38,21 @@ final class MovedClasses implements CompatibilityFix
      */
     public static function register()
     {
-        $autoloader = static function ($oldClassName) {
-            if (! array_key_exists($oldClassName, self::ALIASES)) {
-                return false;
-            }
+        spl_autoload_register(__CLASS__ . '::autoloader');
+    }
 
-            class_alias(self::ALIASES[$oldClassName], $oldClassName, true);
+    /**
+     * Autoloader to register.
+     *
+     * @param string $oldClassName Old class name that was requested to be autoloaded.
+     * @return void
+     */
+    public static function autoloader($oldClassName)
+    {
+        if (! array_key_exists($oldClassName, self::ALIASES)) {
+            return;
+        }
 
-            return true;
-        };
-
-        spl_autoload_register($autoloader);
+        class_alias(self::ALIASES[$oldClassName], $oldClassName, true);
     }
 }

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -38,16 +38,16 @@ final class MovedClasses implements CompatibilityFix
      */
     public static function register()
     {
-        spl_autoload_register(
-            static function ($oldClassName) {
-                if (! array_key_exists($oldClassName, self::ALIASES)) {
-                    return false;
-                }
-
-                class_alias(self::ALIASES[$oldClassName], $oldClassName, true);
-
-                return true;
+        $autoloader = static function ($oldClassName) {
+            if (! array_key_exists($oldClassName, self::ALIASES)) {
+                return false;
             }
-        );
+
+            class_alias(self::ALIASES[$oldClassName], $oldClassName, true);
+
+            return true;
+        };
+
+        spl_autoload_register($autoloader);
     }
 }

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AmpProject\CompatibilityFix;
+
+use AmpProject\CompatibilityFix;
+
+/**
+ * Backwards compatibility fix for classes that were moved.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class MovedClasses implements CompatibilityFix
+{
+
+    /**
+     * Mapping of aliases to be registered.
+     *
+     * @var array<string, string> Associative array of class alias mappings.
+     */
+    const ALIASES = [
+        // v0.9.0 - moving HTML-based utility into a separate `Html` subnamespace.
+        'AmpProject\AtRule'             => 'AmpProject\Html\AtRule',
+        'AmpProject\Attribute'          => 'AmpProject\Html\Attribute',
+        'AmpProject\LengthUnit'         => 'AmpProject\Html\LengthUnit',
+        'AmpProject\RequestDestination' => 'AmpProject\Html\RequestDestination',
+        'AmpProject\Role'               => 'AmpProject\Html\Role',
+        'AmpProject\Tag'                => 'AmpProject\Html\Tag',
+
+        // v0.9.0 - Extracting `Encoding` out of `Dom\Document`, as it is turned into AMP value object.
+        'AmpProject\Dom\Document\Encoding' => 'AmpProject\Encoding',
+
+    ];
+
+    /**
+     * Register the compatibility fix.
+     *
+     * @return void
+     */
+    public static function register()
+    {
+        foreach (self::ALIASES as $old => $new) {
+            if (class_exists($old)) {
+                continue;
+            }
+
+            class_alias($new, $old, true);
+        }
+    }
+}

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -18,7 +18,7 @@ final class MovedClasses implements CompatibilityFix
      * @var array<string, string> Associative array of class alias mappings.
      */
     const ALIASES = [
-        // v0.9.0 - moving HTML-based utility into a separate `Html` subnamespace.
+        // v0.9.0 - moved HTML-based utility into a separate `Html` sub-namespace.
         'AmpProject\AtRule'             => 'AmpProject\Html\AtRule',
         'AmpProject\Attribute'          => 'AmpProject\Html\Attribute',
         'AmpProject\LengthUnit'         => 'AmpProject\Html\LengthUnit',
@@ -26,7 +26,7 @@ final class MovedClasses implements CompatibilityFix
         'AmpProject\Role'               => 'AmpProject\Html\Role',
         'AmpProject\Tag'                => 'AmpProject\Html\Tag',
 
-        // v0.9.0 - Extracting `Encoding` out of `Dom\Document`, as it is turned into AMP value object.
+        // v0.9.0 - extracted `Encoding` out of `Dom\Document`, as it is turned into AMP value object.
         'AmpProject\Dom\Document\Encoding' => 'AmpProject\Encoding',
 
     ];

--- a/tests/CompatibilityFix/MovedClassesTest.php
+++ b/tests/CompatibilityFix/MovedClassesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AmpProject\CompatibilityFix;
+
+use AmpProject\Tests\TestCase;
+
+/**
+ * Tests for AmpProject\CompatibilityFix\MovedClasses.
+ *
+ * @covers \AmpProject\CompatibilityFix\MovedClasses
+ * @package ampproject/amp-toolbox
+ */
+class MovedClassesTest extends TestCase
+{
+
+    public function testClassAliasesExist()
+    {
+        foreach (MovedClasses::ALIASES as $old => $new) {
+            $this->assertTrue(class_exists($old) || interface_exists($old));
+        }
+    }
+}

--- a/tests/CompatibilityFix/MovedClassesTest.php
+++ b/tests/CompatibilityFix/MovedClassesTest.php
@@ -15,7 +15,7 @@ class MovedClassesTest extends TestCase
 
     public function testClassAliasesExist()
     {
-        foreach (MovedClasses::ALIASES as $old => $new) {
+        foreach (array_keys(MovedClasses::ALIASES) as $old) {
             $this->assertTrue(class_exists($old) || interface_exists($old));
         }
     }


### PR DESCRIPTION
This PR adds a mechanism to enforce the loading of compatibility fixes via Composer autoloader includes and provides a compatibility fix to register class aliases for classes that have been moved.

```
        // v0.9.0 - moving HTML-based utility into a separate `Html` subnamespace.
        'AmpProject\AtRule'             => 'AmpProject\Html\AtRule',
        'AmpProject\Attribute'          => 'AmpProject\Html\Attribute',
        'AmpProject\LengthUnit'         => 'AmpProject\Html\LengthUnit',
        'AmpProject\RequestDestination' => 'AmpProject\Html\RequestDestination',
        'AmpProject\Role'               => 'AmpProject\Html\Role',
        'AmpProject\Tag'                => 'AmpProject\Html\Tag',

        // v0.9.0 - Extracting `Encoding` out of `Dom\Document`, as it is turned into AMP value object.
        'AmpProject\Dom\Document\Encoding' => 'AmpProject\Encoding',
```