### PR TITLE
Fix PSR-12 not accepting blank lines after opening brace

### DIFF
--- a/bin/src/Validator/SpecGenerator/ClassNames.php
+++ b/bin/src/Validator/SpecGenerator/ClassNames.php
@@ -4,7 +4,6 @@ namespace AmpProject\Tooling\Validator\SpecGenerator;
 
 trait ClassNames
 {
-
     /**
      * Get a valid PHP class name from an ID string.
      *

--- a/bin/src/Validator/SpecGenerator/ConstantNames.php
+++ b/bin/src/Validator/SpecGenerator/ConstantNames.php
@@ -6,7 +6,6 @@ use AmpProject\Amp;
 
 trait ConstantNames
 {
-
     /**
      * Get the constant name for a given value.
      *

--- a/bin/src/Validator/SpecGenerator/MagicPropertyAnnotations.php
+++ b/bin/src/Validator/SpecGenerator/MagicPropertyAnnotations.php
@@ -4,7 +4,6 @@ namespace AmpProject\Tooling\Validator\SpecGenerator;
 
 trait MagicPropertyAnnotations
 {
-
     /**
      * Get the magic property annotations for a given spec.
      *

--- a/bin/src/Validator/SpecGenerator/ReservedKeywords.php
+++ b/bin/src/Validator/SpecGenerator/ReservedKeywords.php
@@ -4,7 +4,6 @@ namespace AmpProject\Tooling\Validator\SpecGenerator;
 
 final class ReservedKeywords
 {
-
     /**
      * List of reserved keywords.
      *

--- a/bin/src/Validator/SpecGenerator/Section.php
+++ b/bin/src/Validator/SpecGenerator/Section.php
@@ -7,7 +7,6 @@ use Nette\PhpGenerator\PhpNamespace;
 
 interface Section
 {
-
     /**
      * Process a section.
      *

--- a/bin/src/Validator/SpecGenerator/Template/AggregateTag.php
+++ b/bin/src/Validator/SpecGenerator/Template/AggregateTag.php
@@ -15,7 +15,6 @@ use AmpProject\Validator\Spec\Tag;
  */
 final class AggregateTag extends Tag
 {
-
     /**
      * List of spec rules that can be aggregated.
      *

--- a/bin/src/Validator/SpecGenerator/Template/AggregateTagWithExtensionSpec.php
+++ b/bin/src/Validator/SpecGenerator/Template/AggregateTagWithExtensionSpec.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec\TagWithExtensionSpec;
  */
 final class AggregateTagWithExtensionSpec extends TagWithExtensionSpec
 {
-
     /**
      * Array of TagWithExtensionSpec instances that this AggregateTag aggregates.
      *

--- a/bin/src/Validator/SpecGenerator/Template/AttributeList.php
+++ b/bin/src/Validator/SpecGenerator/Template/AttributeList.php
@@ -14,7 +14,6 @@ use AmpProject\Exception\InvalidSpecRuleName;
  */
 abstract class AttributeList
 {
-
     /**
      * ID of the attribute list.
      *

--- a/bin/src/Validator/SpecGenerator/Template/AttributeLists.php
+++ b/bin/src/Validator/SpecGenerator/Template/AttributeLists.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec;
  */
 final class AttributeLists
 {
-
     /** @var array<array> */
     const ATTRIBUTE_LISTS = [];
 

--- a/bin/src/Validator/SpecGenerator/Template/CssRuleset.php
+++ b/bin/src/Validator/SpecGenerator/Template/CssRuleset.php
@@ -25,7 +25,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 abstract class CssRuleset
 {
-
     /**
      * ID of the CSS ruleset.
      *

--- a/bin/src/Validator/SpecGenerator/Template/CssRulesets.php
+++ b/bin/src/Validator/SpecGenerator/Template/CssRulesets.php
@@ -15,7 +15,6 @@ use AmpProject\Validator\Spec\CssRuleset;
  */
 final class CssRulesets
 {
-
     const CSS_RULESETS = [];
 
     const BY_FORMAT = [];

--- a/bin/src/Validator/SpecGenerator/Template/DeclarationList.php
+++ b/bin/src/Validator/SpecGenerator/Template/DeclarationList.php
@@ -14,7 +14,6 @@ use AmpProject\Exception\InvalidSpecRuleName;
  */
 abstract class DeclarationList
 {
-
     /**
      * ID of the declaration list.
      *

--- a/bin/src/Validator/SpecGenerator/Template/DeclarationLists.php
+++ b/bin/src/Validator/SpecGenerator/Template/DeclarationLists.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec;
  */
 final class DeclarationLists
 {
-
     /** @var array<array> */
     const DECLARATION_LISTS = [];
 

--- a/bin/src/Validator/SpecGenerator/Template/DescendantTagList.php
+++ b/bin/src/Validator/SpecGenerator/Template/DescendantTagList.php
@@ -13,7 +13,6 @@ use AmpProject\Exception\InvalidSpecRuleName;
  */
 abstract class DescendantTagList
 {
-
     /**
      * ID of the descendant tag list.
      *

--- a/bin/src/Validator/SpecGenerator/Template/DescendantTagLists.php
+++ b/bin/src/Validator/SpecGenerator/Template/DescendantTagLists.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec;
  */
 final class DescendantTagLists
 {
-
     /** @var array<array> */
     const DESCENDANT_TAG_LISTS = [];
 

--- a/bin/src/Validator/SpecGenerator/Template/DocRuleset.php
+++ b/bin/src/Validator/SpecGenerator/Template/DocRuleset.php
@@ -15,7 +15,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 abstract class DocRuleset
 {
-
     /**
      * ID of the document ruleset.
      *

--- a/bin/src/Validator/SpecGenerator/Template/DocRulesets.php
+++ b/bin/src/Validator/SpecGenerator/Template/DocRulesets.php
@@ -15,7 +15,6 @@ use AmpProject\Validator\Spec\DocRuleset;
  */
 final class DocRulesets
 {
-
     const DOC_RULESETS = [];
 
     const BY_FORMAT = [];

--- a/bin/src/Validator/SpecGenerator/Template/Error.php
+++ b/bin/src/Validator/SpecGenerator/Template/Error.php
@@ -14,7 +14,6 @@ use AmpProject\Exception\InvalidSpecRuleName;
  */
 abstract class Error
 {
-
     /**
      * Code of the error.
      *

--- a/bin/src/Validator/SpecGenerator/Template/Errors.php
+++ b/bin/src/Validator/SpecGenerator/Template/Errors.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec;
  */
 final class Errors
 {
-
     /** @var array<array> */
     const ERRORS = [];
 

--- a/bin/src/Validator/SpecGenerator/Template/Identifiable.php
+++ b/bin/src/Validator/SpecGenerator/Template/Identifiable.php
@@ -9,7 +9,6 @@ namespace AmpProject\Tooling\Validator\SpecGenerator\Template;
  */
 interface Identifiable
 {
-
     /**
      * Get the ID of the identifiable element.
      *

--- a/bin/src/Validator/SpecGenerator/Template/IterableSection.php
+++ b/bin/src/Validator/SpecGenerator/Template/IterableSection.php
@@ -12,7 +12,6 @@ use Iterator;
  */
 interface IterableSection extends Iterator, Countable
 {
-
     /**
      * Get the list of available keys.
      *

--- a/bin/src/Validator/SpecGenerator/Template/Iteration.php
+++ b/bin/src/Validator/SpecGenerator/Template/Iteration.php
@@ -9,7 +9,6 @@ namespace AmpProject\Tooling\Validator\SpecGenerator\Template;
  */
 trait Iteration
 {
-
     /**
      * Array to use for iteration.
      *

--- a/bin/src/Validator/SpecGenerator/Template/Tag.php
+++ b/bin/src/Validator/SpecGenerator/Template/Tag.php
@@ -49,7 +49,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 abstract class Tag
 {
-
     /**
      * ID of the tag.
      *

--- a/bin/src/Validator/SpecGenerator/Template/TagWithExtensionSpec.php
+++ b/bin/src/Validator/SpecGenerator/Template/TagWithExtensionSpec.php
@@ -13,7 +13,6 @@ use AmpProject\Validator\Spec\Tag;
  */
 abstract class TagWithExtensionSpec extends Tag
 {
-
     /**
      * Array of extension spec rules.
      *

--- a/bin/src/Validator/SpecGenerator/Template/Tags.php
+++ b/bin/src/Validator/SpecGenerator/Template/Tags.php
@@ -22,7 +22,6 @@ use LogicException;
  */
 final class Tags
 {
-
     const TAGS = [];
 
     const BY_TAG_NAME       = [];

--- a/src/Amp.php
+++ b/src/Amp.php
@@ -15,7 +15,6 @@ use DOMNode;
  */
 final class Amp
 {
-
     /**
      * Attribute prefix for AMP-bind data attributes.
      *

--- a/src/Cli/AmpExecutable.php
+++ b/src/Cli/AmpExecutable.php
@@ -11,7 +11,6 @@ use AmpProject\Exception\Cli\InvalidCommand;
  */
 final class AmpExecutable extends Executable
 {
-
     /**
      * Array of command classes to register.
      *

--- a/src/Cli/Colors.php
+++ b/src/Cli/Colors.php
@@ -18,7 +18,6 @@ use AmpProject\Exception\Cli\InvalidColor;
  */
 class Colors
 {
-
     const C_BLACK       = 'black';
     const C_BLUE        = 'blue';
     const C_BROWN       = 'brown';

--- a/src/Cli/Command.php
+++ b/src/Cli/Command.php
@@ -9,7 +9,6 @@ namespace AmpProject\Cli;
  */
 abstract class Command
 {
-
     /**
      * Name of the command.
      *

--- a/src/Cli/Command/Optimize.php
+++ b/src/Cli/Command/Optimize.php
@@ -15,7 +15,6 @@ use AmpProject\Optimizer\TransformationEngine;
  */
 final class Optimize extends Command
 {
-
     /**
      * Name of the command.
      *

--- a/src/Cli/Command/Validate.php
+++ b/src/Cli/Command/Validate.php
@@ -17,7 +17,6 @@ use AmpProject\Validator\ValidationStatus;
  */
 final class Validate extends Command
 {
-
     /**
      * Name of the command.
      *

--- a/src/Cli/Executable.php
+++ b/src/Cli/Executable.php
@@ -20,7 +20,6 @@ use Exception;
  */
 abstract class Executable
 {
-
     /**
      * Instance of the Colors helper object.
      *

--- a/src/Cli/LogLevel.php
+++ b/src/Cli/LogLevel.php
@@ -13,7 +13,6 @@ use Exception;
  */
 abstract class LogLevel
 {
-
     /**
      * Detailed debug information.
      *

--- a/src/Cli/Options.php
+++ b/src/Cli/Options.php
@@ -22,7 +22,6 @@ use AmpProject\Exception\Cli\MissingArgument;
  */
 class Options
 {
-
     /**
      * List of options to parse.
      *

--- a/src/Cli/TableFormatter.php
+++ b/src/Cli/TableFormatter.php
@@ -18,7 +18,6 @@ use AmpProject\Exception\Cli\InvalidColumnFormat;
  */
 class TableFormatter
 {
-
     /**
      * Border between columns.
      *

--- a/src/CompatibilityFix.php
+++ b/src/CompatibilityFix.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 interface CompatibilityFix
 {
-
     /**
      * Register the compatibility fix.
      *

--- a/src/CompatibilityFix/MovedClasses.php
+++ b/src/CompatibilityFix/MovedClasses.php
@@ -11,7 +11,6 @@ use AmpProject\CompatibilityFix;
  */
 final class MovedClasses implements CompatibilityFix
 {
-
     /**
      * Mapping of aliases to be registered.
      *

--- a/src/CssLength.php
+++ b/src/CssLength.php
@@ -15,7 +15,6 @@ namespace AmpProject;
  */
 final class CssLength
 {
-
     // Special attribute values.
     const AUTO  = 'auto';
     const FLUID = 'fluid';

--- a/src/DevMode.php
+++ b/src/DevMode.php
@@ -15,7 +15,6 @@ use DOMNode;
  */
 final class DevMode
 {
-
     /**
      * Attribute name for AMP dev mode.
      *

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -48,7 +48,6 @@ use ReflectionNamedType;
  */
 final class Document extends DOMDocument
 {
-
     /**
      * Default document type to use.
      *

--- a/src/Dom/Document/AfterLoadFilter.php
+++ b/src/Dom/Document/AfterLoadFilter.php
@@ -11,7 +11,6 @@ use AmpProject\Dom\Document;
  */
 interface AfterLoadFilter extends Filter
 {
-
     /**
      * Process the Document after the html loaded into the Dom\Document.
      *

--- a/src/Dom/Document/AfterSaveFilter.php
+++ b/src/Dom/Document/AfterSaveFilter.php
@@ -9,7 +9,6 @@ namespace AmpProject\Dom\Document;
  */
 interface AfterSaveFilter extends Filter
 {
-
     /**
      * Process the Dom\Document after being saved from Dom\Document.
      *

--- a/src/Dom/Document/BeforeLoadFilter.php
+++ b/src/Dom/Document/BeforeLoadFilter.php
@@ -9,7 +9,6 @@ namespace AmpProject\Dom\Document;
  */
 interface BeforeLoadFilter extends Filter
 {
-
     /**
      * Preprocess the HTML to be loaded into the Dom\Document.
      *

--- a/src/Dom/Document/BeforeSaveFilter.php
+++ b/src/Dom/Document/BeforeSaveFilter.php
@@ -11,7 +11,6 @@ use AmpProject\Dom\Document;
  */
 interface BeforeSaveFilter extends Filter
 {
-
     /**
      * Preprocess the DOM to be saved into HTML.
      *

--- a/src/Dom/Document/Filter/AmpBindAttributes.php
+++ b/src/Dom/Document/Filter/AmpBindAttributes.php
@@ -15,7 +15,6 @@ use AmpProject\Dom\Options;
  */
 final class AmpBindAttributes implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * Pattern for HTML attribute accounting for binding attr name in data attribute syntax, boolean attribute,
      * single/double-quoted attribute value, and unquoted attribute values.

--- a/src/Dom/Document/Filter/AmpEmojiAttribute.php
+++ b/src/Dom/Document/Filter/AmpEmojiAttribute.php
@@ -14,7 +14,6 @@ use AmpProject\Dom\Document\BeforeLoadFilter;
  */
 final class AmpEmojiAttribute implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * Pattern to match an AMP emoji together with its variant (amp4ads, amp4email, ...).
      *

--- a/src/Dom/Document/Filter/ConvertHeadProfileToLink.php
+++ b/src/Dom/Document/Filter/ConvertHeadProfileToLink.php
@@ -14,7 +14,6 @@ use AmpProject\Html\Tag;
  */
 final class ConvertHeadProfileToLink implements AfterLoadFilter
 {
-
     /**
      * Converts a possible head[profile] attribute to link[rel=profile].
      *

--- a/src/Dom/Document/Filter/DeduplicateTag.php
+++ b/src/Dom/Document/Filter/DeduplicateTag.php
@@ -15,7 +15,6 @@ use DOMAttr;
  */
 final class DeduplicateTag implements AfterLoadFilter
 {
-
     /**
      * Deduplicate head and body tags.
      *

--- a/src/Dom/Document/Filter/DetectInvalidByteSequence.php
+++ b/src/Dom/Document/Filter/DetectInvalidByteSequence.php
@@ -16,7 +16,6 @@ use AmpProject\Exception\InvalidByteSequence;
  */
 final class DetectInvalidByteSequence implements BeforeLoadFilter
 {
-
     /**
      * Options instance to use.
      *

--- a/src/Dom/Document/Filter/DoctypeNode.php
+++ b/src/Dom/Document/Filter/DoctypeNode.php
@@ -12,7 +12,6 @@ use AmpProject\Dom\Document\BeforeLoadFilter;
  */
 final class DoctypeNode implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * Regex pattern used for securing the doctype node if it is not the first one.
      *

--- a/src/Dom/Document/Filter/DocumentEncoding.php
+++ b/src/Dom/Document/Filter/DocumentEncoding.php
@@ -14,7 +14,6 @@ use AmpProject\Html\Tag;
  */
 final class DocumentEncoding implements BeforeLoadFilter
 {
-
     /**
      * Regex pattern to find a tag without an attribute.
      *

--- a/src/Dom/Document/Filter/HttpEquivCharset.php
+++ b/src/Dom/Document/Filter/HttpEquivCharset.php
@@ -19,7 +19,6 @@ use DOMComment;
  */
 final class HttpEquivCharset implements BeforeLoadFilter, AfterLoadFilter, BeforeSaveFilter, AfterSaveFilter
 {
-
     /**
      * Value of the content field of the meta tag for the http-equiv compatibility charset.
      *

--- a/src/Dom/Document/Filter/LibxmlCompatibility.php
+++ b/src/Dom/Document/Filter/LibxmlCompatibility.php
@@ -15,7 +15,6 @@ use AmpProject\Dom\Options;
  */
 final class LibxmlCompatibility implements BeforeLoadFilter, AfterLoadFilter
 {
-
     /**
      * Options instance to use.
      *

--- a/src/Dom/Document/Filter/MustacheScriptTemplates.php
+++ b/src/Dom/Document/Filter/MustacheScriptTemplates.php
@@ -16,7 +16,6 @@ use AmpProject\Html\Tag;
  */
 final class MustacheScriptTemplates implements BeforeLoadFilter, AfterLoadFilter, BeforeSaveFilter, AfterSaveFilter
 {
-
     /**
      * Xpath query to fetch the elements containing Mustache templates (both <template type=amp-mustache> and
      * <script type=text/plain template=amp-mustache>).

--- a/src/Dom/Document/Filter/NormalizeHtmlAttributes.php
+++ b/src/Dom/Document/Filter/NormalizeHtmlAttributes.php
@@ -13,7 +13,6 @@ use DOMAttr;
  */
 final class NormalizeHtmlAttributes implements AfterLoadFilter
 {
-
     /**
      * Normalizes HTML attributes to be HTML5 compatible.
      *

--- a/src/Dom/Document/Filter/NoscriptElements.php
+++ b/src/Dom/Document/Filter/NoscriptElements.php
@@ -15,7 +15,6 @@ use AmpProject\Html\Tag;
  */
 final class NoscriptElements implements BeforeLoadFilter, AfterLoadFilter
 {
-
     /**
      * UniqueIdManager instance to use.
      *

--- a/src/Dom/Document/Filter/ProtectEsiTags.php
+++ b/src/Dom/Document/Filter/ProtectEsiTags.php
@@ -12,7 +12,6 @@ use AmpProject\Dom\Document\BeforeLoadFilter;
  */
 final class ProtectEsiTags implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * List of self-closing ESI tags.
      *

--- a/src/Dom/Document/Filter/SelfClosingSVGElements.php
+++ b/src/Dom/Document/Filter/SelfClosingSVGElements.php
@@ -13,7 +13,6 @@ use AmpProject\Html\Tag;
  */
 final class SelfClosingSVGElements implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * SVG elements that are self-closing.
      *

--- a/src/Dom/Document/Filter/SelfClosingTags.php
+++ b/src/Dom/Document/Filter/SelfClosingTags.php
@@ -13,7 +13,6 @@ use AmpProject\Html\Tag;
  */
 final class SelfClosingTags implements BeforeLoadFilter, AfterSaveFilter
 {
-
     /**
      * Whether the self-closing tags were transformed and need to be restored.
      *

--- a/src/Dom/Document/Filter/SvgSourceAttributeEncoding.php
+++ b/src/Dom/Document/Filter/SvgSourceAttributeEncoding.php
@@ -11,7 +11,6 @@ use AmpProject\Dom\Document\AfterSaveFilter;
  */
 final class SvgSourceAttributeEncoding implements AfterSaveFilter
 {
-
     /**
      * Regex pattern to match an SVG sizer element.
      *

--- a/src/Dom/Document/Option.php
+++ b/src/Dom/Document/Option.php
@@ -9,7 +9,6 @@ namespace AmpProject\Dom\Document;
  */
 interface Option
 {
-
     /**
      * Option to configure the preferred amp-bind syntax.
      *

--- a/src/Dom/Element.php
+++ b/src/Dom/Element.php
@@ -18,7 +18,6 @@ use DOMElement;
  */
 final class Element extends DOMElement
 {
-
     /**
      * Regular expression pattern to match events and actions within an 'on' attribute.
      *

--- a/src/Dom/ElementDump.php
+++ b/src/Dom/ElementDump.php
@@ -15,7 +15,6 @@ use DOMAttr;
  */
 final class ElementDump
 {
-
     /**
      * Element to dump.
      *

--- a/src/Dom/LinkManager.php
+++ b/src/Dom/LinkManager.php
@@ -17,7 +17,6 @@ use DOMNode;
  */
 final class LinkManager
 {
-
     /**
      * List of relations currently managed by the link manager.
      *

--- a/src/Dom/NodeWalker.php
+++ b/src/Dom/NodeWalker.php
@@ -11,7 +11,6 @@ use DOMNode;
  */
 final class NodeWalker
 {
-
     /**
      * Depth-first walk through the DOM tree.
      *

--- a/src/Dom/UniqueIdManager.php
+++ b/src/Dom/UniqueIdManager.php
@@ -9,7 +9,6 @@ namespace AmpProject\Dom;
  */
 final class UniqueIdManager
 {
-
     /**
      * Store the current index by prefix.
      *

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 final class Encoding
 {
-
     /**
      * UTF-8 encoding, which is the fallback.
      *

--- a/src/Exception/AmpCliException.php
+++ b/src/Exception/AmpCliException.php
@@ -9,7 +9,6 @@ namespace AmpProject\Exception;
  */
 interface AmpCliException extends AmpException
 {
-
     /**
      * No error code specified.
      *

--- a/src/Exception/AmpException.php
+++ b/src/Exception/AmpException.php
@@ -9,5 +9,4 @@ namespace AmpProject\Exception;
  */
 interface AmpException
 {
-
 }

--- a/src/Exception/Cli/InvalidArgument.php
+++ b/src/Exception/Cli/InvalidArgument.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
  */
 final class InvalidArgument extends InvalidArgumentException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidArgument exception when arguments could not be read.
      *

--- a/src/Exception/Cli/InvalidColor.php
+++ b/src/Exception/Cli/InvalidColor.php
@@ -12,7 +12,6 @@ use OutOfBoundsException;
  */
 final class InvalidColor extends OutOfBoundsException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidColor exception for an unknown color that was passed to the CLI.
      *

--- a/src/Exception/Cli/InvalidColumnFormat.php
+++ b/src/Exception/Cli/InvalidColumnFormat.php
@@ -12,7 +12,6 @@ use OutOfBoundsException;
  */
 final class InvalidColumnFormat extends OutOfBoundsException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidColumn exception for multiple fluid columns.
      *

--- a/src/Exception/Cli/InvalidCommand.php
+++ b/src/Exception/Cli/InvalidCommand.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
  */
 final class InvalidCommand extends InvalidArgumentException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidCommand exception for an unregistered command that is being referenced.
      *

--- a/src/Exception/Cli/InvalidOption.php
+++ b/src/Exception/Cli/InvalidOption.php
@@ -12,7 +12,6 @@ use OutOfBoundsException;
  */
 final class InvalidOption extends OutOfBoundsException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidOption exception for an unknown option that was passed to the CLI.
      *

--- a/src/Exception/Cli/InvalidSapi.php
+++ b/src/Exception/Cli/InvalidSapi.php
@@ -12,7 +12,6 @@ use OutOfBoundsException;
  */
 final class InvalidSapi extends OutOfBoundsException implements AmpCliException
 {
-
     /**
      * Instantiate an InvalidSapi exception for a SAPI other than 'cli'.
      *

--- a/src/Exception/Cli/MissingArgument.php
+++ b/src/Exception/Cli/MissingArgument.php
@@ -12,7 +12,6 @@ use DomainException;
  */
 final class MissingArgument extends DomainException implements AmpCliException
 {
-
     /**
      * Instantiate a MissingArgument exception for an argument that is required but missing.
      *

--- a/src/Exception/FailedRemoteRequest.php
+++ b/src/Exception/FailedRemoteRequest.php
@@ -9,5 +9,4 @@ namespace AmpProject\Exception;
  */
 interface FailedRemoteRequest extends AmpException
 {
-
 }

--- a/src/Exception/FailedToCreateLink.php
+++ b/src/Exception/FailedToCreateLink.php
@@ -11,7 +11,6 @@ use RuntimeException;
  */
 final class FailedToCreateLink extends RuntimeException implements AmpException
 {
-
     /**
      * Instantiate a FailedToCreateLink exception for a link that could not be created.
      *

--- a/src/Exception/FailedToGetCachedResponse.php
+++ b/src/Exception/FailedToGetCachedResponse.php
@@ -11,7 +11,6 @@ use RuntimeException;
  */
 final class FailedToGetCachedResponse extends RuntimeException implements FailedRemoteRequest
 {
-
     /**
      * Instantiate a FailedToGetCachedResponse exception for a URL if the cached response data could not be
      * retrieved.

--- a/src/Exception/FailedToGetFromRemoteUrl.php
+++ b/src/Exception/FailedToGetFromRemoteUrl.php
@@ -12,7 +12,6 @@ use RuntimeException;
  */
 final class FailedToGetFromRemoteUrl extends RuntimeException implements FailedRemoteRequest
 {
-
     /**
      * Status code of the failed request.
      *

--- a/src/Exception/FailedToParseHtml.php
+++ b/src/Exception/FailedToParseHtml.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
  */
 final class FailedToParseHtml extends InvalidArgumentException implements AmpException
 {
-
     /**
      * Instantiate a FailedToParseHtml exception for a HTML that could not be parsed.
      *

--- a/src/Exception/FailedToParseUrl.php
+++ b/src/Exception/FailedToParseUrl.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class FailedToParseUrl extends InvalidArgumentException implements AmpException
 {
-
     /**
      * Instantiate a FailedToParseUrl exception for a URL that could not be parsed.
      *

--- a/src/Exception/FailedToRetrieveRequiredDomElement.php
+++ b/src/Exception/FailedToRetrieveRequiredDomElement.php
@@ -11,7 +11,6 @@ use LogicException;
  */
 final class FailedToRetrieveRequiredDomElement extends LogicException implements AmpException
 {
-
     /**
      * Instantiate a FailedToRetrieveRequiredDomElement exception for the <html> DOM element.
      *

--- a/src/Exception/InvalidAttributeName.php
+++ b/src/Exception/InvalidAttributeName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidAttributeName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidAttributeName exception for an attribute that is not found within name index.
      *

--- a/src/Exception/InvalidByteSequence.php
+++ b/src/Exception/InvalidByteSequence.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class InvalidByteSequence extends InvalidArgumentException implements AmpException
 {
-
     /**
      * Instantiate a InvalidByteSequence exception for a HTML with invalid byte sequences.
      *

--- a/src/Exception/InvalidCssRulesetName.php
+++ b/src/Exception/InvalidCssRulesetName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidCssRulesetName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidCssRulesetName exception for a CSS ruleset that is not found within the CSS rulesets index.
      *

--- a/src/Exception/InvalidDeclarationName.php
+++ b/src/Exception/InvalidDeclarationName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidDeclarationName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidDeclarationName exception for an declaration that is not found within name index.
      *

--- a/src/Exception/InvalidDocRulesetName.php
+++ b/src/Exception/InvalidDocRulesetName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidDocRulesetName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidDocRulesetName exception for a document ruleset that is not found within the document
      * rulesets index.

--- a/src/Exception/InvalidDocumentFilter.php
+++ b/src/Exception/InvalidDocumentFilter.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class InvalidDocumentFilter extends InvalidArgumentException implements AmpException
 {
-
     /**
      * Instantiate an InvalidDocumentFilter exception for a class that was not a valid filter.
      *

--- a/src/Exception/InvalidErrorCode.php
+++ b/src/Exception/InvalidErrorCode.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidErrorCode extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidErrorCode exception for an unknown error code.
      *

--- a/src/Exception/InvalidExtension.php
+++ b/src/Exception/InvalidExtension.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidExtension extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidExtension exception for an extension that is not found within the extension spec index.
      *

--- a/src/Exception/InvalidFormat.php
+++ b/src/Exception/InvalidFormat.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidFormat extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidFormat exception when an invalid AMP format is being requested.
      *

--- a/src/Exception/InvalidListName.php
+++ b/src/Exception/InvalidListName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidListName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidListName exception for a attribute that is not found within the attribute
      * list name index.

--- a/src/Exception/InvalidSpecName.php
+++ b/src/Exception/InvalidSpecName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidSpecName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidSpecName exception for a spec that is not found within the spec name index.
      *

--- a/src/Exception/InvalidSpecRuleName.php
+++ b/src/Exception/InvalidSpecRuleName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidSpecRuleName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidSpecRuleName exception for a spec rule that is not found within the spec index.
      *

--- a/src/Exception/InvalidTagId.php
+++ b/src/Exception/InvalidTagId.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidTagId extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidTagId exception for a tag that is not found within the tag name index.
      *

--- a/src/Exception/InvalidTagName.php
+++ b/src/Exception/InvalidTagName.php
@@ -11,7 +11,6 @@ use OutOfRangeException;
  */
 final class InvalidTagName extends OutOfRangeException implements AmpException
 {
-
     /**
      * Instantiate an InvalidTagName exception for a tag that is not found within the tag name index.
      *

--- a/src/Exception/MaxCssByteCountExceeded.php
+++ b/src/Exception/MaxCssByteCountExceeded.php
@@ -13,7 +13,6 @@ use OverflowException;
  */
 final class MaxCssByteCountExceeded extends OverflowException implements AmpException
 {
-
     /**
      * Instantiate a MaxCssByteCountExceeded exception for an inline style that exceeds the maximum byte count.
      *

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 interface Extension
 {
-
     const ACCESS                                 = 'amp-access';
     const ACCESS_LATERPAY                        = 'amp-access-laterpay';
     const ACCESS_POOOL                           = 'amp-access-poool';

--- a/src/Format.php
+++ b/src/Format.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 interface Format
 {
-
     /**
      * AMP for websites format.
      *

--- a/src/Html/AtRule.php
+++ b/src/Html/AtRule.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html;
  */
 interface AtRule
 {
-
     const _MOZ_DOCUMENT       = '-moz-document';
     const CHARSET             = 'charset';
     const COUNTER_STYLE       = 'counter-style';

--- a/src/Html/Attribute.php
+++ b/src/Html/Attribute.php
@@ -11,7 +11,6 @@ namespace AmpProject\Html;
  */
 interface Attribute
 {
-
     const ABBR                            = 'abbr';
     const ABOUT                           = 'about';
     const ACCEPT                          = 'accept';

--- a/src/Html/LengthUnit.php
+++ b/src/Html/LengthUnit.php
@@ -13,7 +13,6 @@ namespace AmpProject\Html;
  */
 final class LengthUnit
 {
-
     /**
      * Centimeters.
      *

--- a/src/Html/LowerCaseTag.php
+++ b/src/Html/LowerCaseTag.php
@@ -9,5 +9,4 @@ namespace AmpProject\Html;
  */
 interface LowerCaseTag extends Tag
 {
-
 }

--- a/src/Html/Parser/DocLocator.php
+++ b/src/Html/Parser/DocLocator.php
@@ -11,7 +11,6 @@ use AmpProject\Str;
  */
 final class DocLocator
 {
-
     /**
      * Line mapped to a given position.
      *

--- a/src/Html/Parser/EFlags.php
+++ b/src/Html/Parser/EFlags.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html\Parser;
  */
 interface EFlags
 {
-
     const OPTIONAL_ENDTAG   = 1;
     const EMPTY_            = 2;
     const CDATA             = 4;

--- a/src/Html/Parser/HtmlParser.php
+++ b/src/Html/Parser/HtmlParser.php
@@ -16,7 +16,6 @@ use AmpProject\Str;
  */
 final class HtmlParser
 {
-
     /**
      * Regular expression that matches the next token to be processed.
      *

--- a/src/Html/Parser/HtmlSaxHandler.php
+++ b/src/Html/Parser/HtmlSaxHandler.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html\Parser;
  */
 interface HtmlSaxHandler
 {
-
     /**
      * Handler called when the parser found a new tag.
      *

--- a/src/Html/Parser/HtmlSaxHandlerWithLocation.php
+++ b/src/Html/Parser/HtmlSaxHandlerWithLocation.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html\Parser;
  */
 interface HtmlSaxHandlerWithLocation extends HtmlSaxHandler
 {
-
     /**
      * Called prior to parsing a document, that is, before startTag().
      *

--- a/src/Html/Parser/ParsedAttribute.php
+++ b/src/Html/Parser/ParsedAttribute.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html\Parser;
  */
 final class ParsedAttribute
 {
-
     /**
      * Name of the attribute.
      *

--- a/src/Html/Parser/ParsedTag.php
+++ b/src/Html/Parser/ParsedTag.php
@@ -12,7 +12,6 @@ use AmpProject\Str;
  */
 final class ParsedTag
 {
-
     /**
      * Name of the parsed tag.
      *

--- a/src/Html/Parser/ScriptTag.php
+++ b/src/Html/Parser/ScriptTag.php
@@ -15,7 +15,6 @@ use AmpProject\Str;
  */
 final class ScriptTag
 {
-
     /**
      * Name of the tag.
      *

--- a/src/Html/Parser/TagNameStack.php
+++ b/src/Html/Parser/TagNameStack.php
@@ -19,7 +19,6 @@ use AmpProject\Str;
  */
 final class TagNameStack
 {
-
     /**
      * Regular expression that matches strings composed of all space characters, as defined in
      * https://infra.spec.whatwg.org/#ascii-whitespace, and in the various HTML parsing rules at

--- a/src/Html/Parser/TagRegion.php
+++ b/src/Html/Parser/TagRegion.php
@@ -20,7 +20,6 @@ use AmpProject\FakeEnum;
  */
 final class TagRegion extends FakeEnum
 {
-
     const PRE_DOCTYPE = 0;
     const PRE_HTML    = 1;
     const PRE_HEAD    = 2;

--- a/src/Html/RequestDestination.php
+++ b/src/Html/RequestDestination.php
@@ -15,7 +15,6 @@ namespace AmpProject\Html;
  */
 interface RequestDestination
 {
-
     /**
      * Audio file, as typically used in <audio>.
      *

--- a/src/Html/Role.php
+++ b/src/Html/Role.php
@@ -11,7 +11,6 @@ namespace AmpProject\Html;
  */
 interface Role
 {
-
     /**
      * A message with an alert or error information.
      *

--- a/src/Html/Tag.php
+++ b/src/Html/Tag.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html;
  */
 interface Tag
 {
-
     const A                   = 'a';
     const ABBR                = 'abbr';
     const ACRONYM             = 'acronym';

--- a/src/Html/UpperCaseTag.php
+++ b/src/Html/UpperCaseTag.php
@@ -9,7 +9,6 @@ namespace AmpProject\Html;
  */
 interface UpperCaseTag
 {
-
     const A                   = 'A';
     const ABBR                = 'ABBR';
     const ACRONYM             = 'ACRONYM';

--- a/src/Layout.php
+++ b/src/Layout.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 interface Layout
 {
-
     const NODISPLAY    = 'nodisplay';
     const FIXED        = 'fixed';
     const RESPONSIVE   = 'responsive';

--- a/src/Optimizer/Configuration.php
+++ b/src/Optimizer/Configuration.php
@@ -11,7 +11,6 @@ use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
  */
 interface Configuration
 {
-
     /**
      * Key to use for managing the array of active transformers.
      *

--- a/src/Optimizer/Configuration/AmpRuntimeCssConfiguration.php
+++ b/src/Optimizer/Configuration/AmpRuntimeCssConfiguration.php
@@ -16,7 +16,6 @@ use AmpProject\RuntimeVersion;
  */
 final class AmpRuntimeCssConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Configuration key that holds the flag for the canary version of the runtime style.
      *

--- a/src/Optimizer/Configuration/AutoExtensionsConfiguration.php
+++ b/src/Optimizer/Configuration/AutoExtensionsConfiguration.php
@@ -20,7 +20,6 @@ use ReflectionClass;
  */
 final class AutoExtensionsConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Configuration key that specifies the AMP format.
      *

--- a/src/Optimizer/Configuration/BaseTransformerConfiguration.php
+++ b/src/Optimizer/Configuration/BaseTransformerConfiguration.php
@@ -16,7 +16,6 @@ use AmpProject\Optimizer\TransformerConfiguration;
  */
 abstract class BaseTransformerConfiguration implements TransformerConfiguration
 {
-
     /**
      * Associative array of allowed keys and their respective default values.
      *

--- a/src/Optimizer/Configuration/MinifyHtmlConfiguration.php
+++ b/src/Optimizer/Configuration/MinifyHtmlConfiguration.php
@@ -20,7 +20,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class MinifyHtmlConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Whether minification is enabled.
      *

--- a/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeAmpBindConfiguration.php
@@ -13,7 +13,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class OptimizeAmpBindConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Whether the amp-bind optimizer is enabled.
      *

--- a/src/Optimizer/Configuration/OptimizeHeroImagesConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeHeroImagesConfiguration.php
@@ -18,7 +18,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class OptimizeHeroImagesConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Configuration key that holds the attribute that is used to store inline styles that
      * were moved to <style amp-custom>.

--- a/src/Optimizer/Configuration/OptimizeViewportConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeViewportConfiguration.php
@@ -14,7 +14,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class OptimizeViewportConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Whether we should remove the initial-scale=1 in order to avoid a tap delay that hurts FID.
      *

--- a/src/Optimizer/Configuration/PreloadHeroImageConfiguration.php
+++ b/src/Optimizer/Configuration/PreloadHeroImageConfiguration.php
@@ -19,7 +19,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class PreloadHeroImageConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Configuration key that holds the attribute that is used to store inline styles that
      * were moved to <style amp-custom>.

--- a/src/Optimizer/Configuration/RewriteAmpUrlsConfiguration.php
+++ b/src/Optimizer/Configuration/RewriteAmpUrlsConfiguration.php
@@ -19,7 +19,6 @@ use AmpProject\Optimizer\Exception\InvalidConfigurationValue;
  */
 final class RewriteAmpUrlsConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Specifies a specific version of the AMP runtime.
      *

--- a/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
+++ b/src/Optimizer/Configuration/TransformedIdentifierConfiguration.php
@@ -17,7 +17,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 final class TransformedIdentifierConfiguration extends BaseTransformerConfiguration
 {
-
     /**
      * Configuration key that holds the version number to use.
      *

--- a/src/Optimizer/CssRule.php
+++ b/src/Optimizer/CssRule.php
@@ -14,7 +14,6 @@ namespace AmpProject\Optimizer;
  */
 final class CssRule
 {
-
     /**
      * Characters to use for trimming CSS values.
      *

--- a/src/Optimizer/CssRules.php
+++ b/src/Optimizer/CssRules.php
@@ -14,7 +14,6 @@ namespace AmpProject\Optimizer;
  */
 final class CssRules
 {
-
     /**
      * Internal array of CssRule objects.
      *

--- a/src/Optimizer/DefaultConfiguration.php
+++ b/src/Optimizer/DefaultConfiguration.php
@@ -13,7 +13,6 @@ use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
  */
 class DefaultConfiguration implements Configuration
 {
-
     /**
      * Associative array of already validated configuration settings.
      *

--- a/src/Optimizer/Error.php
+++ b/src/Optimizer/Error.php
@@ -9,7 +9,6 @@ namespace AmpProject\Optimizer;
  */
 interface Error
 {
-
     /**
      * Get the code of the error.
      *

--- a/src/Optimizer/Error/ErrorProperties.php
+++ b/src/Optimizer/Error/ErrorProperties.php
@@ -11,7 +11,6 @@ use ReflectionClass;
  */
 trait ErrorProperties
 {
-
     /**
      * Instantiate an Error object.
      *

--- a/src/Optimizer/ErrorCollection.php
+++ b/src/Optimizer/ErrorCollection.php
@@ -13,7 +13,6 @@ use IteratorAggregate;
  */
 final class ErrorCollection implements Countable, IteratorAggregate
 {
-
     /**
      * Internal storage for the errors that were added.
      *

--- a/src/Optimizer/Exception/AmpOptimizerException.php
+++ b/src/Optimizer/Exception/AmpOptimizerException.php
@@ -11,5 +11,4 @@ use AmpProject\Exception\AmpException;
  */
 interface AmpOptimizerException extends AmpException
 {
-
 }

--- a/src/Optimizer/Exception/InvalidArgument.php
+++ b/src/Optimizer/Exception/InvalidArgument.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class InvalidArgument extends InvalidArgumentException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an InvalidArgument exception for an invalid argument type for numeric comparison.
      *

--- a/src/Optimizer/Exception/InvalidConfiguration.php
+++ b/src/Optimizer/Exception/InvalidConfiguration.php
@@ -11,7 +11,6 @@ use DomainException;
  */
 final class InvalidConfiguration extends DomainException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an InvalidConfiguration exception for two mutually exclusive flags.
      *

--- a/src/Optimizer/Exception/InvalidConfigurationKey.php
+++ b/src/Optimizer/Exception/InvalidConfigurationKey.php
@@ -11,7 +11,6 @@ use OutOfBoundsException;
  */
 final class InvalidConfigurationKey extends OutOfBoundsException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an InvalidConfigurationKey exception for an invalid key.
      *

--- a/src/Optimizer/Exception/InvalidConfigurationValue.php
+++ b/src/Optimizer/Exception/InvalidConfigurationValue.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class InvalidConfigurationValue extends InvalidArgumentException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an InvalidConfigurationValue exception for an invalid value type.
      *

--- a/src/Optimizer/Exception/InvalidHtmlAttribute.php
+++ b/src/Optimizer/Exception/InvalidHtmlAttribute.php
@@ -13,7 +13,6 @@ use DomainException;
  */
 final class InvalidHtmlAttribute extends DomainException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an InvalidHtmlAttribute exception for an invalid attribute value.
      *

--- a/src/Optimizer/Exception/UnknownConfigurationClass.php
+++ b/src/Optimizer/Exception/UnknownConfigurationClass.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class UnknownConfigurationClass extends InvalidArgumentException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an UnknownConfigurationClass exception for an unknown configuration class.
      *

--- a/src/Optimizer/Exception/UnknownConfigurationKey.php
+++ b/src/Optimizer/Exception/UnknownConfigurationKey.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
  */
 final class UnknownConfigurationKey extends InvalidArgumentException implements AmpOptimizerException
 {
-
     /**
      * Instantiate an UnknownConfigurationKey exception for an unknown key.
      *

--- a/src/Optimizer/HeroImage.php
+++ b/src/Optimizer/HeroImage.php
@@ -13,7 +13,6 @@ use AmpProject\Dom\Element;
  */
 final class HeroImage
 {
-
     /**
      * <amp-img> element wrapping the actual hero image.
      *

--- a/src/Optimizer/ImageDimensions.php
+++ b/src/Optimizer/ImageDimensions.php
@@ -9,7 +9,6 @@ use AmpProject\Html\LengthUnit;
 
 final class ImageDimensions
 {
-
     /**
      * Regular expression pattern to match the trailing unit of a dimension.
      *

--- a/src/Optimizer/LocalFallback.php
+++ b/src/Optimizer/LocalFallback.php
@@ -6,7 +6,6 @@ use AmpProject\Amp;
 
 final class LocalFallback
 {
-
     /**
      * Domain for which the mapped files will have a local fallback.
      */

--- a/src/Optimizer/TransformationEngine.php
+++ b/src/Optimizer/TransformationEngine.php
@@ -17,7 +17,6 @@ use ReflectionException;
  */
 final class TransformationEngine
 {
-
     /**
      * Internal storage for the configuration settings.
      *

--- a/src/Optimizer/Transformer.php
+++ b/src/Optimizer/Transformer.php
@@ -11,7 +11,6 @@ use AmpProject\Dom\Document;
  */
 interface Transformer
 {
-
     /**
      * Apply transformations to the provided DOM document.
      *

--- a/src/Optimizer/Transformer/AmpBoilerplate.php
+++ b/src/Optimizer/Transformer/AmpBoilerplate.php
@@ -25,7 +25,6 @@ use AmpProject\Html\Tag;
  */
 final class AmpBoilerplate implements Transformer
 {
-
     /**
      * Apply transformations to the provided DOM document.
      *

--- a/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
+++ b/src/Optimizer/Transformer/AmpBoilerplateErrorHandler.php
@@ -18,7 +18,6 @@ use AmpProject\Html\Tag;
  */
 final class AmpBoilerplateErrorHandler implements Transformer
 {
-
     /**
      * XPath query to find an AMP runtime script using ES6 modules.
      *

--- a/src/Optimizer/Transformer/AmpRuntimeCss.php
+++ b/src/Optimizer/Transformer/AmpRuntimeCss.php
@@ -35,7 +35,6 @@ use Exception;
  */
 final class AmpRuntimeCss implements Transformer
 {
-
     /**
      * XPath query to fetch the <style amp-runtime> element.
      *

--- a/src/Optimizer/Transformer/GoogleFontsPreconnect.php
+++ b/src/Optimizer/Transformer/GoogleFontsPreconnect.php
@@ -13,7 +13,6 @@ use AmpProject\Optimizer\Transformer;
  */
 final class GoogleFontsPreconnect implements Transformer
 {
-
     /**
      * Domain that the Google Fonts static files are loaded from.
      *

--- a/src/Optimizer/Transformer/MinifyHtml.php
+++ b/src/Optimizer/Transformer/MinifyHtml.php
@@ -29,7 +29,6 @@ use Peast\Renderer;
  */
 final class MinifyHtml implements Transformer
 {
-
     /**
      * Configuration store to use.
      *

--- a/src/Optimizer/Transformer/OptimizeAmpBind.php
+++ b/src/Optimizer/Transformer/OptimizeAmpBind.php
@@ -29,7 +29,6 @@ use DOMAttr;
  */
 final class OptimizeAmpBind implements Transformer
 {
-
     /**
      * Configuration store to use.
      *

--- a/src/Optimizer/Transformer/OptimizeHeroImages.php
+++ b/src/Optimizer/Transformer/OptimizeHeroImages.php
@@ -47,7 +47,6 @@ use AmpProject\Url;
  */
 final class OptimizeHeroImages implements Transformer
 {
-
     /**
      * Class(es) to apply to a serverside-rendered image element.
      *

--- a/src/Optimizer/Transformer/OptimizeViewport.php
+++ b/src/Optimizer/Transformer/OptimizeViewport.php
@@ -23,7 +23,6 @@ use AmpProject\Html\Tag;
  */
 final class OptimizeViewport implements Transformer
 {
-
     /**
      * Viewport settings to use for AMP markup.
      *

--- a/src/Optimizer/Transformer/PreloadHeroImage.php
+++ b/src/Optimizer/Transformer/PreloadHeroImage.php
@@ -37,7 +37,6 @@ use AmpProject\Optimizer\TransformerConfiguration;
  */
 final class PreloadHeroImage implements Transformer
 {
-
     /**
      * Class(es) to apply to a serverside-rendered image element.
      *

--- a/src/Optimizer/Transformer/ReorderHead.php
+++ b/src/Optimizer/Transformer/ReorderHead.php
@@ -45,7 +45,6 @@ use DOMNodeList;
  */
 final class ReorderHead implements Transformer
 {
-
     /**
      * Regular expression pattern to match resource hints pointing to an AMP resource.
      */

--- a/src/Optimizer/Transformer/RewriteAmpUrls.php
+++ b/src/Optimizer/Transformer/RewriteAmpUrls.php
@@ -58,7 +58,6 @@ use Exception;
  */
 final class RewriteAmpUrls implements Transformer
 {
-
     /**
      * Configuration to use.
      *

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -39,7 +39,6 @@ use Exception;
  */
 final class ServerSideRendering implements Transformer
 {
-
     /**
      * List of layouts that support server-side rendering.
      *

--- a/src/Optimizer/Transformer/TransformedIdentifier.php
+++ b/src/Optimizer/Transformer/TransformedIdentifier.php
@@ -27,7 +27,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 final class TransformedIdentifier implements Transformer
 {
-
     /**
      * Attribute name of the "transformed" identifier.
      *

--- a/src/Optimizer/TransformerConfiguration.php
+++ b/src/Optimizer/TransformerConfiguration.php
@@ -11,7 +11,6 @@ use AmpProject\Optimizer\Exception\UnknownConfigurationKey;
  */
 interface TransformerConfiguration
 {
-
     /**
      * Get the value for a given key.
      *

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 interface Protocol
 {
-
     const AMP_SCRIPT    = 'amp-script';
     const AMP_STATE     = 'amp-state';
     const BBMI          = 'bbmi';

--- a/src/RemoteGetRequest.php
+++ b/src/RemoteGetRequest.php
@@ -13,7 +13,6 @@ use AmpProject\Exception\FailedRemoteRequest;
  */
 interface RemoteGetRequest
 {
-
     /**
      * Do a GET request to retrieve the contents of a remote URL.
      *

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -14,7 +14,6 @@ use AmpProject\Response;
  */
 final class CurlRemoteGetRequest implements RemoteGetRequest
 {
-
     /**
      * Default timeout value to use in seconds.
      *

--- a/src/RemoteRequest/FallbackRemoteGetRequest.php
+++ b/src/RemoteRequest/FallbackRemoteGetRequest.php
@@ -19,7 +19,6 @@ use Exception;
  */
 final class FallbackRemoteGetRequest implements RemoteGetRequest
 {
-
     /**
      * Array of RemoteGetRequest instances to churn through.
      *

--- a/src/RemoteRequest/FilesystemRemoteGetRequest.php
+++ b/src/RemoteRequest/FilesystemRemoteGetRequest.php
@@ -17,7 +17,6 @@ use LogicException;
  */
 final class FilesystemRemoteGetRequest implements RemoteGetRequest
 {
-
     /**
      * Associative array of data for mapping between arguments and filepaths pointing to the results to return.
      *

--- a/src/RemoteRequest/RemoteGetRequestResponse.php
+++ b/src/RemoteRequest/RemoteGetRequestResponse.php
@@ -11,7 +11,6 @@ use AmpProject\Response;
  */
 final class RemoteGetRequestResponse implements Response
 {
-
     /**
      * Body of the response.
      *

--- a/src/RemoteRequest/StubbedRemoteGetRequest.php
+++ b/src/RemoteRequest/StubbedRemoteGetRequest.php
@@ -14,7 +14,6 @@ use LogicException;
  */
 final class StubbedRemoteGetRequest implements RemoteGetRequest
 {
-
     /**
      * Associative array of data for mapping between arguments and returned results.
      *

--- a/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
+++ b/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
@@ -15,7 +15,6 @@ use Exception;
  */
 final class TemporaryFileCachedRemoteGetRequest implements RemoteGetRequest
 {
-
     /**
      * Prefix to use to identify cached file.
      *

--- a/src/Response.php
+++ b/src/Response.php
@@ -14,7 +14,6 @@ namespace AmpProject;
  */
 interface Response
 {
-
     /**
      * Retrieves all message header values.
      *

--- a/src/RuntimeVersion.php
+++ b/src/RuntimeVersion.php
@@ -35,7 +35,6 @@ namespace AmpProject;
  */
 final class RuntimeVersion
 {
-
     /**
      * Option to retrieve the latest canary version data instead of the production version data.
      *

--- a/src/ScriptReleaseVersion.php
+++ b/src/ScriptReleaseVersion.php
@@ -15,7 +15,6 @@ namespace AmpProject;
  */
 final class ScriptReleaseVersion extends FakeEnum
 {
-
     const UNKNOWN             = 'unknown';
     const STANDARD            = 'standard';
     const LTS                 = 'lts';

--- a/src/Str.php
+++ b/src/Str.php
@@ -9,7 +9,6 @@ namespace AmpProject;
  */
 final class Str
 {
-
     /**
      * Whether to try to use multibyte functions.
      *

--- a/src/Url.php
+++ b/src/Url.php
@@ -20,7 +20,6 @@ use AmpProject\Exception\FailedToParseUrl;
  */
 final class Url
 {
-
     const SCHEME   = 'scheme';
     const HOST     = 'host';
     const PORT     = 'port';

--- a/src/Validator/Context.php
+++ b/src/Validator/Context.php
@@ -14,7 +14,6 @@ use AmpProject\Html\Parser\ParsedAttribute;
  */
 final class Context
 {
-
     /**
      * Validator rules to be applied.
      *

--- a/src/Validator/ExtensionsContext.php
+++ b/src/Validator/ExtensionsContext.php
@@ -12,7 +12,6 @@ use AmpProject\Extension;
  */
 final class ExtensionsContext
 {
-
     /**
      * Extensions that have been already loaded.
      *

--- a/src/Validator/FilePosition.php
+++ b/src/Validator/FilePosition.php
@@ -9,7 +9,6 @@ namespace AmpProject\Validator;
  */
 final class FilePosition
 {
-
     /**
      * Line position into the file.
      *

--- a/src/Validator/ValidateTagResult.php
+++ b/src/Validator/ValidateTagResult.php
@@ -9,7 +9,6 @@ namespace AmpProject\Validator;
  */
 final class ValidateTagResult
 {
-
     /**
      * Validation result.
      *

--- a/src/Validator/ValidationEngine.php
+++ b/src/Validator/ValidationEngine.php
@@ -13,7 +13,6 @@ use AmpProject\Html\Parser\HtmlParser;
  */
 final class ValidationEngine
 {
-
     /**
      * Validate the provided DOM document.
      *

--- a/src/Validator/ValidationError.php
+++ b/src/Validator/ValidationError.php
@@ -9,7 +9,6 @@ namespace AmpProject\Validator;
  */
 final class ValidationError
 {
-
     /**
      * Severity of the validation error.
      *

--- a/src/Validator/ValidationErrorCollection.php
+++ b/src/Validator/ValidationErrorCollection.php
@@ -12,7 +12,6 @@ use Iterator;
  */
 final class ValidationErrorCollection implements Countable, Iterator
 {
-
     /**
      * Internal storage for the errors that were added.
      *

--- a/src/Validator/ValidationHandler.php
+++ b/src/Validator/ValidationHandler.php
@@ -21,7 +21,6 @@ use AmpProject\Validator\Spec\Error\InvalidDoctypeHtml;
  */
 final class ValidationHandler implements HtmlSaxHandlerWithLocation
 {
-
     /**
      * AMP HTML format to validate against.
      *

--- a/src/Validator/ValidationResult.php
+++ b/src/Validator/ValidationResult.php
@@ -9,7 +9,6 @@ namespace AmpProject\Validator;
  */
 final class ValidationResult
 {
-
     /**
      * Validation result status.
      *

--- a/src/Validator/ValidatorRules.php
+++ b/src/Validator/ValidatorRules.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec\Error\MandatoryAttrMissing;
 
 final class ValidatorRules
 {
-
     /**
      * Regular expression to validate the value of a transformed attribute.
      *

--- a/src/Validator/ValueSetProvision.php
+++ b/src/Validator/ValueSetProvision.php
@@ -9,5 +9,4 @@ namespace AmpProject\Validator;
  */
 final class ValueSetProvision
 {
-
 }

--- a/src/Validator/ValueSetRequirement.php
+++ b/src/Validator/ValueSetRequirement.php
@@ -9,5 +9,4 @@ namespace AmpProject\Validator;
  */
 final class ValueSetRequirement
 {
-
 }

--- a/tests/AmpTest.php
+++ b/tests/AmpTest.php
@@ -17,7 +17,6 @@ use DOMNode;
  */
 class AmpTest extends TestCase
 {
-
     /**
      * Provide data for the testIsRuntimeScript() method.
      *

--- a/tests/Cli/ColorsTest.php
+++ b/tests/Cli/ColorsTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class ColorsTest extends TestCase
 {
-
     public function testInstantiation()
     {
         // No TERM present, color should be the result of posix_isatty(STDOUT).

--- a/tests/CompatibilityFix/MovedClassesTest.php
+++ b/tests/CompatibilityFix/MovedClassesTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class MovedClassesTest extends TestCase
 {
-
     public function testClassAliasesExist()
     {
         foreach (array_keys(MovedClasses::ALIASES) as $old) {

--- a/tests/CssLengthTest.php
+++ b/tests/CssLengthTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 class CssLengthTest extends TestCase
 {
-
     public function dataCssLength()
     {
         return [

--- a/tests/DevModeTest.php
+++ b/tests/DevModeTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 class DevModeTest extends TestCase
 {
-
     public function dataIsActiveForDocument()
     {
         return [

--- a/tests/Dom/OptionsTest.php
+++ b/tests/Dom/OptionsTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class OptionsTest extends TestCase
 {
-
     /**
      * Test setting default options.
      *

--- a/tests/Exception/Cli/InvalidArgumentTest.php
+++ b/tests/Exception/Cli/InvalidArgumentTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidArgumentTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an unreadable file.
      */

--- a/tests/Exception/Cli/InvalidColorTest.php
+++ b/tests/Exception/Cli/InvalidColorTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidColorTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an unknown color.
      */

--- a/tests/Exception/Cli/InvalidColumnFormatTest.php
+++ b/tests/Exception/Cli/InvalidColumnFormatTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidColumnFormatTest extends TestCase
 {
-
     /**
      * Test throwing the exception for multiple fluid columns.
      */

--- a/tests/Exception/Cli/InvalidCommandTest.php
+++ b/tests/Exception/Cli/InvalidCommandTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidCommandTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an unregistered command.
      */

--- a/tests/Exception/Cli/InvalidOptionTest.php
+++ b/tests/Exception/Cli/InvalidOptionTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidOptionTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an unknown option.
      */

--- a/tests/Exception/Cli/InvalidSapiTest.php
+++ b/tests/Exception/Cli/InvalidSapiTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidSapiTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a SAPI.
      */

--- a/tests/Exception/Cli/MissingArgumentTest.php
+++ b/tests/Exception/Cli/MissingArgumentTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class MissingArgumentTest extends TestCase
 {
-
     /**
      * Test throwing the exception for no argument.
      */

--- a/tests/Exception/FailedToGetCachedResponseTest.php
+++ b/tests/Exception/FailedToGetCachedResponseTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class FailedToGetCachedResponseTest extends TestCase
 {
-
     /**
      * Test throwing the exception with a URL.
      */

--- a/tests/Exception/FailedToGetFromRemoteUrlTest.php
+++ b/tests/Exception/FailedToGetFromRemoteUrlTest.php
@@ -13,7 +13,6 @@ use RuntimeException;
  */
 class FailedToGetFromRemoteUrlTest extends TestCase
 {
-
     /**
      * Test throwing the exception with a URL and an HTTP status.
      */

--- a/tests/Exception/FailedToRetrieveRequiredDomElementTest.php
+++ b/tests/Exception/FailedToRetrieveRequiredDomElementTest.php
@@ -13,7 +13,6 @@ use stdClass;
  */
 class FailedToRetrieveRequiredDomElementTest extends TestCase
 {
-
     /**
      * Provide data for the <html> element.
      *

--- a/tests/Exception/InvalidAttributeNameTest.php
+++ b/tests/Exception/InvalidAttributeNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidAttributeNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an attribute.
      */

--- a/tests/Exception/InvalidCssRulesetNameTest.php
+++ b/tests/Exception/InvalidCssRulesetNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidCssRulesetNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a CSS name.
      */

--- a/tests/Exception/InvalidDeclarationNametest.php
+++ b/tests/Exception/InvalidDeclarationNametest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidDeclarationNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an invalid declaration name.
      */

--- a/tests/Exception/InvalidDocRulesetNameTest.php
+++ b/tests/Exception/InvalidDocRulesetNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidDocRulesetNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a document ruleset name.
      */

--- a/tests/Exception/InvalidErrorCodeTest.php
+++ b/tests/Exception/InvalidErrorCodeTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidErrorCodeTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a error code.
      */

--- a/tests/Exception/InvalidExtensionTest.php
+++ b/tests/Exception/InvalidExtensionTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidExtensionTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an extension.
      */

--- a/tests/Exception/InvalidFormatTest.php
+++ b/tests/Exception/InvalidFormatTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidFormatTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an format.
      */

--- a/tests/Exception/InvalidListNameTest.php
+++ b/tests/Exception/InvalidListNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidListNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an attribute list.
      */

--- a/tests/Exception/InvalidSpecNameTest.php
+++ b/tests/Exception/InvalidSpecNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidSpecNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a spec name.
      */

--- a/tests/Exception/InvalidSpecRuleNameTest.php
+++ b/tests/Exception/InvalidSpecRuleNameTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidSpecRuleNameTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a spec rule name.
      */

--- a/tests/Exception/InvalidTagIdTest.php
+++ b/tests/Exception/InvalidTagIdTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class InvalidTagIdTest extends TestCase
 {
-
     /**
      * Test throwing the exception for a tag ID.
      */

--- a/tests/Exception/MaxCssByteCountExceededTest.php
+++ b/tests/Exception/MaxCssByteCountExceededTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 class MaxCssByteCountExceededTest extends TestCase
 {
-
     /**
      * Test throwing the exception for an inline style.
      */

--- a/tests/Html/LengthUnitTest.php
+++ b/tests/Html/LengthUnitTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class LengthUnitTest extends TestCase
 {
-
     /**
      * Provide data to test conversions into pixels.
      *

--- a/tests/Html/Parser/DocLocatorTest.php
+++ b/tests/Html/Parser/DocLocatorTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class DocLocatorTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Html\Parser\DocLocator::__construct()
      * @covers \AmpProject\Html\Parser\DocLocator::getDocumentByteSize()

--- a/tests/Html/Parser/HtmlParserTest.php
+++ b/tests/Html/Parser/HtmlParserTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 class HtmlParserTest extends TestCase
 {
-
     public function dataParsing()
     {
         return [

--- a/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
+++ b/tests/Optimizer/Configuration/AmpRuntimeCssConfigurationTest.php
@@ -18,7 +18,6 @@ use stdClass;
  */
 final class AmpRuntimeCssConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new AmpRuntimeCssConfiguration([]);

--- a/tests/Optimizer/Configuration/OptimizeAmpBindConfigurationTest.php
+++ b/tests/Optimizer/Configuration/OptimizeAmpBindConfigurationTest.php
@@ -18,7 +18,6 @@ use stdClass;
  */
 final class OptimizeAmpBindConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new OptimizeAmpBindConfiguration([]);

--- a/tests/Optimizer/Configuration/OptimizeHeroImagesConfigurationTest.php
+++ b/tests/Optimizer/Configuration/OptimizeHeroImagesConfigurationTest.php
@@ -18,7 +18,6 @@ use stdClass;
  */
 final class OptimizeHeroImagesConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new OptimizeHeroImagesConfiguration([]);

--- a/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
+++ b/tests/Optimizer/Configuration/PreloadHeroImageConfigurationTest.php
@@ -18,7 +18,6 @@ use stdClass;
  */
 final class PreloadHeroImageConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new PreloadHeroImageConfiguration([]);

--- a/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
+++ b/tests/Optimizer/Configuration/RewriteAmpUrlsConfigurationTest.php
@@ -19,7 +19,6 @@ use stdClass;
  */
 final class RewriteAmpUrlsConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new RewriteAmpUrlsConfiguration([]);

--- a/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
+++ b/tests/Optimizer/Configuration/TransformedIdentifierConfigurationTest.php
@@ -20,7 +20,6 @@ use stdClass;
  */
 final class TransformedIdentifierConfigurationTest extends TestCase
 {
-
     public function testDefaults()
     {
         $configuration = new TransformedIdentifierConfiguration([]);

--- a/tests/Optimizer/CssRuleTest.php
+++ b/tests/Optimizer/CssRuleTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class CssRuleTest extends TestCase
 {
-
     public function dataCssRuleOutput()
     {
         // ID will always be set to i-amp-42 for the tests.

--- a/tests/Optimizer/CssRulesTest.php
+++ b/tests/Optimizer/CssRulesTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class CssRulesTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Optimizer\CssRules::getCss()
      */

--- a/tests/Optimizer/DefaultConfigurationTest.php
+++ b/tests/Optimizer/DefaultConfigurationTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 final class DefaultConfigurationTest extends TestCase
 {
-
     /**
      * Test whether we can retrieve the default configuration.
      *

--- a/tests/Optimizer/ErrorCollectionTest.php
+++ b/tests/Optimizer/ErrorCollectionTest.php
@@ -14,7 +14,6 @@ use ReflectionClass;
  */
 final class ErrorCollectionTest extends TestCase
 {
-
     /**
      * Test whether we can add errors to the collection.
      *

--- a/tests/Optimizer/ImageDimensionsTest.php
+++ b/tests/Optimizer/ImageDimensionsTest.php
@@ -18,7 +18,6 @@ use stdClass;
  */
 class ImageDimensionsTest extends TestCase
 {
-
     /**
      * Test instantiating the ImageDimensions object.
      *

--- a/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
+++ b/tests/Optimizer/Transformer/OptimizeAmpBindTest.php
@@ -18,7 +18,6 @@ use AmpProject\Tests\TestCase;
  */
 final class OptimizeAmpBindTest extends TestCase
 {
-
     const HTML = '
         <!doctype html>
         <html ⚡>

--- a/tests/RemoteRequest/CurlRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/CurlRemoteGetRequestTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class CurlRemoteGetRequestTest extends TestCase
 {
-
     public function testInstantiation()
     {
         $curlRequest = new CurlRemoteGetRequest(false, -1, -1);

--- a/tests/RemoteRequest/FilesystemRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/FilesystemRemoteGetRequestTest.php
@@ -13,7 +13,6 @@ use LogicException;
  */
 class FilesystemRemoteGetRequestTest extends TestCase
 {
-
     const MAPPING = [
         'https://example.com/existing-file'     => __DIR__ . '/RemoteGetRequestResponseTest.php',
         'https://example.com/non-existing-file' => __DIR__ . '/Nonsense.php',

--- a/tests/RemoteRequest/RemoteGetRequestResponseTest.php
+++ b/tests/RemoteRequest/RemoteGetRequestResponseTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class RemoteGetRequestResponseTest extends TestCase
 {
-
     public function testGetData()
     {
         $response = new RemoteGetRequestResponse(

--- a/tests/RemoteRequest/StubbedRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/StubbedRemoteGetRequestTest.php
@@ -13,7 +13,6 @@ use LogicException;
  */
 class StubbedRemoteGetRequestTest extends TestCase
 {
-
     public function testGetReturnsStubbedUrl()
     {
         $stubbedRequest = new StubbedRemoteGetRequest(

--- a/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
@@ -17,7 +17,6 @@ use org\bovigo\vfs\vfsStream;
  */
 class TemporaryFileCachedRemoteGetRequestTest extends TestCase
 {
-
     /**
      * The test directory name.
      *

--- a/tests/RuntimeVersionTest.php
+++ b/tests/RuntimeVersionTest.php
@@ -14,7 +14,6 @@ use AmpProject\Tests\TestCase;
  */
 class RuntimeVersionTest extends TestCase
 {
-
     /**
      * Associative array of mapping data for stubbing remote requests.
      *

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -12,7 +12,6 @@ use AmpProject\Tests\TestCase;
  */
 class StrTest extends TestCase
 {
-
     public function dataLength()
     {
         return [

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -13,7 +13,6 @@ use AmpProject\Tests\TestCase;
  */
 class UrlTest extends TestCase
 {
-
     public function dataParsing()
     {
         return [

--- a/tests/Validator/Spec/AttributeListTest.php
+++ b/tests/Validator/Spec/AttributeListTest.php
@@ -8,7 +8,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyAttributeList;
 
 class AttributeListTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\AttributeList::getId()
      * @covers \AmpProject\Validator\Spec\AttributeList::get()

--- a/tests/Validator/Spec/DeclarationListTest.php
+++ b/tests/Validator/Spec/DeclarationListTest.php
@@ -8,7 +8,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyDeclarationList;
 
 class DeclarationListTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\DeclarationList::getId()
      * @covers \AmpProject\Validator\Spec\DeclarationList::get()

--- a/tests/Validator/Spec/DescendantTagListTest.php
+++ b/tests/Validator/Spec/DescendantTagListTest.php
@@ -7,7 +7,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyDescendantTagList;
 
 class DescendantTagListTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\DescendantTagList::getId()
      * @covers \AmpProject\Validator\Spec\DescendantTagList::has()

--- a/tests/Validator/Spec/ErrorTest.php
+++ b/tests/Validator/Spec/ErrorTest.php
@@ -8,7 +8,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyError;
 
 class ErrorTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\Error::getCode()
      * @covers \AmpProject\Validator\Spec\Error::get()

--- a/tests/Validator/Spec/TagTest.php
+++ b/tests/Validator/Spec/TagTest.php
@@ -8,7 +8,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyTag;
 
 class TagTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\Tag::get()
      * @covers \AmpProject\Validator\Spec\Tag::has()

--- a/tests/Validator/Spec/TagWithExtensionSpecTest.php
+++ b/tests/Validator/Spec/TagWithExtensionSpecTest.php
@@ -7,7 +7,6 @@ use AmpProject\Tests\ValidatorFixtures\DummyTagWithExtensionSpec;
 
 class TagWithExtensionSpecTest extends TestCase
 {
-
     /**
      * @covers \AmpProject\Validator\Spec\TagWithExtensionSpec::getExtensionName()
      */

--- a/tests/Validator/SpecTest.php
+++ b/tests/Validator/SpecTest.php
@@ -13,7 +13,6 @@ use AmpProject\Validator\Spec\Section;
  */
 class SpecTest extends TestCase
 {
-
     public function testItCanBeInstantiated()
     {
         $spec = new Spec();

--- a/tests/Validator/ValidationEngineTest.php
+++ b/tests/Validator/ValidationEngineTest.php
@@ -14,7 +14,6 @@ use AmpProject\Validator\Spec\Error;
  */
 class ValidationEngineTest extends TestCase
 {
-
     public function dataValidateHtml()
     {
         return [

--- a/tests/src/ErrorComparison.php
+++ b/tests/src/ErrorComparison.php
@@ -13,7 +13,6 @@ use ReflectionClass;
  */
 trait ErrorComparison
 {
-
     /**
      * Assert that two sets of errors are the same.
      *

--- a/tests/src/LoggingHtmlSaxHandler.php
+++ b/tests/src/LoggingHtmlSaxHandler.php
@@ -13,7 +13,6 @@ use AmpProject\Html\Parser\ParsedTag;
  */
 final class LoggingHtmlSaxHandler implements HtmlSaxHandler
 {
-
     /**
      * Log storage.
      *

--- a/tests/src/LoggingHtmlSaxHandlerWithLocation.php
+++ b/tests/src/LoggingHtmlSaxHandlerWithLocation.php
@@ -14,7 +14,6 @@ use AmpProject\Html\Parser\ParsedTag;
  */
 final class LoggingHtmlSaxHandlerWithLocation implements HtmlSaxHandlerWithLocation
 {
-
     /**
      * DocLocator instance to use.
      *

--- a/tests/src/MarkupComparison.php
+++ b/tests/src/MarkupComparison.php
@@ -9,7 +9,6 @@ namespace AmpProject\Tests;
  */
 trait MarkupComparison
 {
-
     /**
      * Assert markup is equal.
      *

--- a/tests/src/PrivateAccess.php
+++ b/tests/src/PrivateAccess.php
@@ -14,7 +14,6 @@ use ReflectionException;
  */
 trait PrivateAccess
 {
-
     /**
      * Call a private method as if it was public.
      *

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -11,5 +11,4 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfilledTestCase;
  */
 abstract class TestCase extends PolyfilledTestCase
 {
-
 }

--- a/tests/src/TestMarkup.php
+++ b/tests/src/TestMarkup.php
@@ -15,7 +15,6 @@ namespace AmpProject\Tests;
  */
 final class TestMarkup
 {
-
     /**
      * Associative array of mapping data for stubbing remote requests.
      *

--- a/tests/src/TestTransformer/ConfigurationOnly.php
+++ b/tests/src/TestTransformer/ConfigurationOnly.php
@@ -9,7 +9,6 @@ use AmpProject\Optimizer\TransformerConfiguration;
 
 final class ConfigurationOnly implements Transformer
 {
-
     public function __construct(TransformerConfiguration $configuration)
     {
     }

--- a/tests/src/TestTransformer/ConfigurationThenRemoteRequest.php
+++ b/tests/src/TestTransformer/ConfigurationThenRemoteRequest.php
@@ -10,7 +10,6 @@ use AmpProject\RemoteGetRequest;
 
 final class ConfigurationThenRemoteRequest implements Transformer
 {
-
     public function __construct(TransformerConfiguration $configuration, RemoteGetRequest $remoteRequest)
     {
     }

--- a/tests/src/TestTransformer/DummyTransformerConfiguration.php
+++ b/tests/src/TestTransformer/DummyTransformerConfiguration.php
@@ -6,7 +6,6 @@ use AmpProject\Optimizer\TransformerConfiguration;
 
 final class DummyTransformerConfiguration implements TransformerConfiguration
 {
-
     public function get($key)
     {
     }

--- a/tests/src/TestTransformer/NoConstructor.php
+++ b/tests/src/TestTransformer/NoConstructor.php
@@ -8,7 +8,6 @@ use AmpProject\Optimizer\Transformer;
 
 final class NoConstructor implements Transformer
 {
-
     public function transform(Document $document, ErrorCollection $errors)
     {
     }

--- a/tests/src/TestTransformer/NoDependencies.php
+++ b/tests/src/TestTransformer/NoDependencies.php
@@ -8,7 +8,6 @@ use AmpProject\Optimizer\Transformer;
 
 final class NoDependencies implements Transformer
 {
-
     public function __construct()
     {
     }

--- a/tests/src/TestTransformer/RemoteRequestOnly.php
+++ b/tests/src/TestTransformer/RemoteRequestOnly.php
@@ -9,7 +9,6 @@ use AmpProject\RemoteGetRequest;
 
 final class RemoteRequestOnly implements Transformer
 {
-
     public function __construct(RemoteGetRequest $remoteRequest)
     {
     }

--- a/tests/src/TestTransformer/RemoteRequestThenConfiguration.php
+++ b/tests/src/TestTransformer/RemoteRequestThenConfiguration.php
@@ -10,7 +10,6 @@ use AmpProject\RemoteGetRequest;
 
 final class RemoteRequestThenConfiguration implements Transformer
 {
-
     public function __construct(RemoteGetRequest $remoteRequest, TransformerConfiguration $configuration)
     {
     }

--- a/tests/src/ValidatorFixtures/DummyAttributeList.php
+++ b/tests/src/ValidatorFixtures/DummyAttributeList.php
@@ -13,7 +13,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 class DummyAttributeList extends AttributeList
 {
-
     /** @var string */
     const ID = 'dummy';
 

--- a/tests/src/ValidatorFixtures/DummyCssRuleset.php
+++ b/tests/src/ValidatorFixtures/DummyCssRuleset.php
@@ -10,7 +10,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 class DummyCssRuleset extends CssRuleset
 {
-
     /** @var string */
     const ID = 'dummy';
 

--- a/tests/src/ValidatorFixtures/DummyDocRuleset.php
+++ b/tests/src/ValidatorFixtures/DummyDocRuleset.php
@@ -10,7 +10,6 @@ use AmpProject\Validator\Spec\SpecRule;
  */
 class DummyDocRuleset extends DocRuleset
 {
-
     /** @var string */
     const ID = 'DUMMY';
 

--- a/tests/src/ValidatorFixtures/DummyError.php
+++ b/tests/src/ValidatorFixtures/DummyError.php
@@ -7,7 +7,6 @@ use AmpProject\Validator\Spec\SpecRule;
 
 class DummyError extends Error
 {
-
     /** @var string */
     const CODE = 'dummy';
 

--- a/tests/src/ValidatorFixtures/DummyTag.php
+++ b/tests/src/ValidatorFixtures/DummyTag.php
@@ -11,7 +11,6 @@ use AmpProject\Validator\Spec\Tag;
  */
 class DummyTag extends Tag
 {
-
     /** @var string */
     const ID = 'dummy';
 

--- a/tests/src/ValidatorFixtures/DummyTagWithExtensionSpec.php
+++ b/tests/src/ValidatorFixtures/DummyTagWithExtensionSpec.php
@@ -11,7 +11,6 @@ use AmpProject\Validator\Spec\TagWithExtensionSpec;
  */
 class DummyTagWithExtensionSpec extends TagWithExtensionSpec
 {
-
     /** @var string */
     const ID = 'dummy';
 


### PR DESCRIPTION
Seems like a new rule was activated with a dependency update, and most of our test files are failing PHPCS because of a blank line after the opening brace.

This fixes that.