### PR TITLE
Add NormalizeHtmlEntities filter

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -204,6 +204,7 @@ final class Document extends DOMDocument
                 Filter\HttpEquivCharset::class,
                 Filter\LibxmlCompatibility::class,
                 Filter\ProtectEsiTags::class,
+                Filter\HtmlEntities::class,
             ]
         );
     }

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -204,7 +204,7 @@ final class Document extends DOMDocument
                 Filter\HttpEquivCharset::class,
                 Filter\LibxmlCompatibility::class,
                 Filter\ProtectEsiTags::class,
-                Filter\HtmlEntities::class,
+                Filter\NormalizeHtmlEntities::class,
             ]
         );
     }

--- a/src/Dom/Document/Filter/HtmlEntities.php
+++ b/src/Dom/Document/Filter/HtmlEntities.php
@@ -11,7 +11,7 @@ use AmpProject\Dom\Options;
  *
  * @package ampproject/amp-toolbox
  */
-final class HtmlEntities implements BeforeLoadFilter
+final class NormalizeHtmlEntities implements BeforeLoadFilter
 {
     /**
      * Options instance to use.
@@ -76,6 +76,7 @@ final class HtmlEntities implements BeforeLoadFilter
      */
     protected function hasHtmlEntities($html)
     {
+		// TODO: Discuss other popular entities to look for, especially for languages with different punctuation symbols.
         return preg_match('/&comma;|&period;|&excl;|&quest;/', $html);
     }
 }

--- a/src/Dom/Document/Filter/HtmlEntities.php
+++ b/src/Dom/Document/Filter/HtmlEntities.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AmpProject\Dom\Document\Filter;
+
+use AmpProject\Dom\Document\BeforeLoadFilter;
+use AmpProject\Dom\Document\Option;
+use AmpProject\Dom\Options;
+
+/**
+ * Handles the html entities present in the html and prevent them from double encoding.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class HtmlEntities implements BeforeLoadFilter
+{
+
+    /**
+     * Options instance to use.
+     *
+     * @var Options
+     */
+    private $options;
+
+    /**
+     * Whether to use this HtmlEntities or not.
+     *
+     * Possible values are 'auto', true and false.
+     *
+     * @var string|bool
+     */
+    private $filterHtmlEntities;
+
+    /**
+     * HtmlEntities constructor.
+     *
+     * @param Options $options Options instance to use.
+     */
+    public function __construct(Options $options)
+    {
+        $this->options = $options;
+
+        if (! isset($options[Option::FILTER_HTML_ENTITIES]) || $options[Option::FILTER_HTML_ENTITIES] === 'auto') {
+            $this->filterHtmlEntities = 'auto';
+        } else {
+            $this->filterHtmlEntities = (bool) $options[Option::FILTER_HTML_ENTITIES];
+        }
+    }
+
+    /**
+     * Preprocess the HTML to be loaded into the Dom\Document.
+     *
+     * @param string $html String of HTML markup to be preprocessed.
+     * @return string Preprocessed string of HTML markup.
+     */
+    public function beforeLoad($html)
+    {
+        if (! $this->filterHtmlEntities) {
+            return $html;
+        }
+
+        if (($this->filterHtmlEntities === Option::FILTER_HTML_ENTITIES_AUTO) && ! $this->hasHtmlEntities($html)) {
+            return $html;
+        }
+
+        return html_entity_decode(
+            $html,
+            $this->options[Option::FILTER_HTML_ENTITIES_FLAGS],
+            $this->options[Option::ENCODING]
+        );
+    }
+
+    /**
+     * Detect the presence of html entities in the html.
+     *
+     * @param string $html The html in which this method will to detect the entities.
+     * @return bool Whether the html contains entities or not.
+     */
+    protected function hasHtmlEntities($html)
+    {
+        return preg_match('/&comma;|&period;|&excl;|&quest;/', $html);
+    }
+}

--- a/src/Dom/Document/Filter/HtmlEntities.php
+++ b/src/Dom/Document/Filter/HtmlEntities.php
@@ -13,7 +13,6 @@ use AmpProject\Dom\Options;
  */
 final class HtmlEntities implements BeforeLoadFilter
 {
-
     /**
      * Options instance to use.
      *

--- a/src/Dom/Document/Filter/NormalizeHtmlEntities.php
+++ b/src/Dom/Document/Filter/NormalizeHtmlEntities.php
@@ -8,7 +8,7 @@ use AmpProject\Dom\Options;
 use AmpProject\Exception\InvalidOptionValue;
 
 /**
- * Handles the html entities present in the html and prevent them from double encoding.
+ * Handles the html entities present in the html and prevents them from double encoding.
  *
  * @package ampproject/amp-toolbox
  */
@@ -28,7 +28,7 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
     private $options;
 
     /**
-     * Whether to use this NormalizeHtmlEntities or not.
+     * Whether to use the NormalizeHtmlEntities filter or not.
      *
      * Accepted values are 'auto', 'always' and 'never'.
      *

--- a/src/Dom/Document/Filter/NormalizeHtmlEntities.php
+++ b/src/Dom/Document/Filter/NormalizeHtmlEntities.php
@@ -5,6 +5,7 @@ namespace AmpProject\Dom\Document\Filter;
 use AmpProject\Dom\Document\BeforeLoadFilter;
 use AmpProject\Dom\Document\Option;
 use AmpProject\Dom\Options;
+use AmpProject\Exception\InvalidOptionValue;
 
 /**
  * Handles the html entities present in the html and prevent them from double encoding.
@@ -13,6 +14,12 @@ use AmpProject\Dom\Options;
  */
 final class NormalizeHtmlEntities implements BeforeLoadFilter
 {
+    const VALID_NORMALIZE_OPTION_VALUES = [
+        Option::NORMALIZE_HTML_ENTITIES_AUTO,
+        Option::NORMALIZE_HTML_ENTITIES_ALWAYS,
+        Option::NORMALIZE_HTML_ENTITIES_NEVER,
+    ];
+
     /**
      * Options instance to use.
      *
@@ -33,15 +40,21 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
      * NormalizeHtmlEntities constructor.
      *
      * @param Options $options Options instance to use.
+     *
+     * @throws InvalidOptionValue If invalid value is set to normalize_html_entities option.
      */
     public function __construct(Options $options)
     {
         $this->options = $options;
 
-		$this->normalizeHtmlEntities = $options[Option::NORMALIZE_HTML_ENTITIES];
-		if (! in_array($this->normalizeHtmlEntities, self::VALID_NORMALIZE_OPTION_VALUES, true)) {
-			throw InvalidOptionValue::forValue($this->normalizeHtmlEntities, self::VALID_NORMALIZE_OPTION_VALUES);
-		}
+        $this->normalizeHtmlEntities = $options[Option::NORMALIZE_HTML_ENTITIES];
+        if (! in_array($this->normalizeHtmlEntities, self::VALID_NORMALIZE_OPTION_VALUES, true)) {
+            throw InvalidOptionValue::forValue(
+                Option::NORMALIZE_HTML_ENTITIES,
+                self::VALID_NORMALIZE_OPTION_VALUES,
+                $this->normalizeHtmlEntities
+            );
+        }
     }
 
     /**

--- a/src/Dom/Document/Filter/NormalizeHtmlEntities.php
+++ b/src/Dom/Document/Filter/NormalizeHtmlEntities.php
@@ -21,16 +21,16 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
     private $options;
 
     /**
-     * Whether to use this HtmlEntities or not.
+     * Whether to use this NormalizeHtmlEntities or not.
      *
-     * Possible values are 'auto', true and false.
+     * Accepted values are 'auto', 'always' and 'never'.
      *
-     * @var string|bool
+     * @var string
      */
-    private $filterHtmlEntities;
+    private $normalizeHtmlEntities;
 
     /**
-     * HtmlEntities constructor.
+     * NormalizeHtmlEntities constructor.
      *
      * @param Options $options Options instance to use.
      */
@@ -38,10 +38,17 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
     {
         $this->options = $options;
 
-        if (! isset($options[Option::FILTER_HTML_ENTITIES]) || $options[Option::FILTER_HTML_ENTITIES] === 'auto') {
-            $this->filterHtmlEntities = 'auto';
-        } else {
-            $this->filterHtmlEntities = (bool) $options[Option::FILTER_HTML_ENTITIES];
+        switch ($options[Option::NORMALIZE_HTML_ENTITIES]) {
+            case Option::NORMALIZE_HTML_ENTITIES_NEVER:
+                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_NEVER;
+                break;
+            case Option::NORMALIZE_HTML_ENTITIES_ALWAYS:
+                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_ALWAYS;
+                break;
+            case Option::NORMALIZE_HTML_ENTITIES_AUTO:
+            default:
+                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_AUTO;
+                break;
         }
     }
 
@@ -53,17 +60,19 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
      */
     public function beforeLoad($html)
     {
-        if (! $this->filterHtmlEntities) {
-            return $html;
-        }
-
-        if (($this->filterHtmlEntities === Option::FILTER_HTML_ENTITIES_AUTO) && ! $this->hasHtmlEntities($html)) {
+        if (
+            ($this->normalizeHtmlEntities === Option::NORMALIZE_HTML_ENTITIES_NEVER)
+            || (
+                ($this->normalizeHtmlEntities === Option::NORMALIZE_HTML_ENTITIES_AUTO)
+                && ! $this->hasHtmlEntities($html)
+            )
+        ) {
             return $html;
         }
 
         return html_entity_decode(
             $html,
-            $this->options[Option::FILTER_HTML_ENTITIES_FLAGS],
+            $this->options[Option::NORMALIZE_HTML_ENTITIES_FLAGS],
             $this->options[Option::ENCODING]
         );
     }
@@ -76,7 +85,8 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
      */
     protected function hasHtmlEntities($html)
     {
-		// TODO: Discuss other popular entities to look for, especially for languages with different punctuation symbols.
+        // TODO: Discuss other popular entities to look for, especially for languages
+        // with different punctuation symbols.
         return preg_match('/&comma;|&period;|&excl;|&quest;/', $html);
     }
 }

--- a/src/Dom/Document/Filter/NormalizeHtmlEntities.php
+++ b/src/Dom/Document/Filter/NormalizeHtmlEntities.php
@@ -38,18 +38,10 @@ final class NormalizeHtmlEntities implements BeforeLoadFilter
     {
         $this->options = $options;
 
-        switch ($options[Option::NORMALIZE_HTML_ENTITIES]) {
-            case Option::NORMALIZE_HTML_ENTITIES_NEVER:
-                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_NEVER;
-                break;
-            case Option::NORMALIZE_HTML_ENTITIES_ALWAYS:
-                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_ALWAYS;
-                break;
-            case Option::NORMALIZE_HTML_ENTITIES_AUTO:
-            default:
-                $this->normalizeHtmlEntities = Option::NORMALIZE_HTML_ENTITIES_AUTO;
-                break;
-        }
+		$this->normalizeHtmlEntities = $options[Option::NORMALIZE_HTML_ENTITIES];
+		if (! in_array($this->normalizeHtmlEntities, self::VALID_NORMALIZE_OPTION_VALUES, true)) {
+			throw InvalidOptionValue::forValue($this->normalizeHtmlEntities, self::VALID_NORMALIZE_OPTION_VALUES);
+		}
     }
 
     /**

--- a/src/Dom/Document/Option.php
+++ b/src/Dom/Document/Option.php
@@ -38,20 +38,20 @@ interface Option
     const CHECK_ENCODING = 'check_encoding';
 
     /**
-     * Option to use the HtmlEntities filter.
+     * Option to use the NormalizeHtmlEntities filter.
      *
-     * Accepted values are 'auto', true and false.
+     * Accepted values are 'auto', 'always' and 'never'.
      *
      * @var string
      */
-    const FILTER_HTML_ENTITIES = 'filter_html_entities';
+    const NORMALIZE_HTML_ENTITIES = 'normalize_html_entities';
 
     /**
      * Flags option for html entities.
      *
      * @var string
      */
-    const FILTER_HTML_ENTITIES_FLAGS = 'filter_html_entities_flags';
+    const NORMALIZE_HTML_ENTITIES_FLAGS = 'normalize_html_entities_flags';
 
     /**
      * Associative array of known options and their respective default value.
@@ -59,12 +59,12 @@ interface Option
      * @var array
      */
     const DEFAULTS = [
-        self::AMP_BIND_SYNTAX             => self::AMP_BIND_SYNTAX_AUTO,
-        self::ENCODING                    => null,
-        self::LIBXML_FLAGS                => 0,
-        self::CHECK_ENCODING              => false,
-        self::FILTER_HTML_ENTITIES        => self::FILTER_HTML_ENTITIES_AUTO,
-        self::FILTER_HTML_ENTITIES_FLAGS  => ENT_HTML5,
+        self::AMP_BIND_SYNTAX                => self::AMP_BIND_SYNTAX_AUTO,
+        self::ENCODING                       => null,
+        self::LIBXML_FLAGS                   => 0,
+        self::CHECK_ENCODING                 => false,
+        self::NORMALIZE_HTML_ENTITIES        => self::NORMALIZE_HTML_ENTITIES_AUTO,
+        self::NORMALIZE_HTML_ENTITIES_FLAGS  => ENT_HTML5,
     ];
 
     /**
@@ -89,9 +89,23 @@ interface Option
     const AMP_BIND_SYNTAX_SQUARE_BRACKETS = 'square_brackets';
 
     /**
-     * Possible value 'auto' for the 'filter_html_entities' option.
+     * Possible value 'auto' for the 'normalize_html_entities' option.
      *
      * @var string
      */
-    const FILTER_HTML_ENTITIES_AUTO = 'auto';
+    const NORMALIZE_HTML_ENTITIES_AUTO = 'auto';
+
+    /**
+     * Possible value 'always' for the 'normalize_html_entities' option.
+     *
+     * @var string
+     */
+    const NORMALIZE_HTML_ENTITIES_ALWAYS = 'always';
+
+    /**
+     * Possible value 'never' for the 'normalize_html_entities' option.
+     *
+     * @var string
+     */
+    const NORMALIZE_HTML_ENTITIES_NEVER = 'never';
 }

--- a/src/Dom/Document/Option.php
+++ b/src/Dom/Document/Option.php
@@ -38,15 +38,33 @@ interface Option
     const CHECK_ENCODING = 'check_encoding';
 
     /**
+     * Option to use the HtmlEntities filter.
+     *
+     * Accepted values are 'auto', true and false.
+     *
+     * @var string
+     */
+    const FILTER_HTML_ENTITIES = 'filter_html_entities';
+
+    /**
+     * Flags option for html entities.
+     *
+     * @var string
+     */
+    const FILTER_HTML_ENTITIES_FLAGS = 'filter_html_entities_flags';
+
+    /**
      * Associative array of known options and their respective default value.
      *
      * @var array
      */
     const DEFAULTS = [
-        self::AMP_BIND_SYNTAX => self::AMP_BIND_SYNTAX_AUTO,
-        self::ENCODING        => null,
-        self::LIBXML_FLAGS    => 0,
-        self::CHECK_ENCODING  => false,
+        self::AMP_BIND_SYNTAX             => self::AMP_BIND_SYNTAX_AUTO,
+        self::ENCODING                    => null,
+        self::LIBXML_FLAGS                => 0,
+        self::CHECK_ENCODING              => false,
+        self::FILTER_HTML_ENTITIES        => self::FILTER_HTML_ENTITIES_AUTO,
+        self::FILTER_HTML_ENTITIES_FLAGS  => ENT_HTML5,
     ];
 
     /**
@@ -69,4 +87,11 @@ interface Option
      * @var string
      */
     const AMP_BIND_SYNTAX_SQUARE_BRACKETS = 'square_brackets';
+
+    /**
+     * Possible value 'auto' for the 'filter_html_entities' option.
+     *
+     * @var string
+     */
+    const FILTER_HTML_ENTITIES_AUTO = 'auto';
 }

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -1488,7 +1488,7 @@ class DocumentTest extends TestCase
     }
 
     /**
-     * Data for AmpProject\Dom\Document test.
+     * Data for AmpProject\Dom\Document\Filter\HtmlEntities test.
      *
      * @return array Data.
      */
@@ -1506,7 +1506,7 @@ class DocumentTest extends TestCase
                 . '</body></html>',
                 []
             ],
-            'do_not_filter_entities' => [
+            'html_entities_filtering_can_be_disabled' => [
                 '<!DOCTYPE html><html><head></head><body>'
                 . '<p>Lorem ipsum dolor sit&comma; amet consectetur</p>'
                 . '</body></html>',
@@ -1521,6 +1521,7 @@ class DocumentTest extends TestCase
     }
 
     /**
+     * Test HtmlEntities document filter.
      *
      * @param string $source   Source content.
      * @param string $expected Expected target content.

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -1488,7 +1488,7 @@ class DocumentTest extends TestCase
     }
 
     /**
-     * Data for AmpProject\Dom\Document\Filter\HtmlEntities test.
+     * Data for AmpProject\Dom\Document\Filter\NormalizeHtmlEntities test.
      *
      * @return array Data.
      */
@@ -1506,7 +1506,7 @@ class DocumentTest extends TestCase
                 . '</body></html>',
                 []
             ],
-            'html_entities_filtering_can_be_disabled' => [
+            'normalizing_html_entities_can_be_disabled' => [
                 '<!DOCTYPE html><html><head></head><body>'
                 . '<p>Lorem ipsum dolor sit&comma; amet consectetur</p>'
                 . '</body></html>',
@@ -1514,14 +1514,37 @@ class DocumentTest extends TestCase
                 . '<p>Lorem ipsum dolor sit&amp;comma; amet consectetur</p>'
                 . '</body></html>',
                 [
-                    Option::FILTER_HTML_ENTITIES => false,
+                    Option::NORMALIZE_HTML_ENTITIES => Option::NORMALIZE_HTML_ENTITIES_NEVER,
+                ]
+            ],
+            'normalize_using_custom_flags' => [
+                '<!DOCTYPE html><html><head></head><body>'
+                . '<p>A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;&period;</p>'
+                . '</body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body>'
+                . '<p>A \'quote\' is <b>bold</b>&amp;period;</p>'
+                . '</body></html>',
+                [
+                    Option::NORMALIZE_HTML_ENTITIES       => Option::NORMALIZE_HTML_ENTITIES_ALWAYS,
+                    Option::NORMALIZE_HTML_ENTITIES_FLAGS => ENT_QUOTES,
+                ]
+            ],
+            'single_and_double_quotes_always_converted_by_DOMDocument_saveHTML_method' => [
+                '<!DOCTYPE html><html><head></head><body>'
+                . '<p>Lorem &quot;ipsum&quot; &apos;dolor&apos; sit amet&comma; consectetur&semi; adipisicing elit</p>'
+                . '</body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body>'
+                . '<p>Lorem "ipsum" \'dolor\' sit amet&amp;comma; consectetur&amp;semi; adipisicing elit</p>'
+                . '</body></html>',
+                [
+                    Option::NORMALIZE_HTML_ENTITIES_FLAGS => ENT_NOQUOTES,
                 ]
             ],
         ];
     }
 
     /**
-     * Test HtmlEntities document filter.
+     * Test NormalizeHtmlEntities document filter.
      *
      * @param string $source   Source content.
      * @param string $expected Expected target content.
@@ -1529,7 +1552,7 @@ class DocumentTest extends TestCase
      *
      * @dataProvider dataHtmlEntities
      *
-     * @covers \AmpProject\Dom\Document\Filter\HtmlEntities::beforeLoad()
+     * @covers \AmpProject\Dom\Document\Filter\NormalizeHtmlEntities::beforeLoad()
      */
     public function testHtmlEntities($source, $expected, $options)
     {

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -3,10 +3,11 @@
 namespace AmpProject\Dom;
 
 use AmpProject\Amp;
-use AmpProject\Html\Attribute;
 use AmpProject\Dom\Document\Option;
 use AmpProject\Exception\InvalidByteSequence;
+use AmpProject\Exception\InvalidOptionValue;
 use AmpProject\Exception\MaxCssByteCountExceeded;
+use AmpProject\Html\Attribute;
 use AmpProject\Html\Tag;
 use AmpProject\Tests\MarkupComparison;
 use AmpProject\Tests\TestCase;
@@ -1554,11 +1555,32 @@ class DocumentTest extends TestCase
      *
      * @covers \AmpProject\Dom\Document\Filter\NormalizeHtmlEntities::beforeLoad()
      */
-    public function testHtmlEntities($source, $expected, $options)
+    public function testNormalizeHtmlEntities($source, $expected, $options)
     {
         $document = Document::fromHtml($source, $options);
         $output   = $document->saveHTML();
 
         $this->assertEqualMarkup($expected, $output);
+    }
+
+    /**
+     * Test NormalizeHtmlEntities throws exception for invalid option value.
+     *
+     * @covers \AmpProject\Dom\Document\Filter\NormalizeHtmlEntities::__construct()
+     */
+    public function testInvalidOptionValueThrowsByNormalizeHtmlEntities()
+    {
+        $this->expectException(InvalidOptionValue::class);
+        $this->expectExceptionMessage(
+            "The value for the option 'normalize_html_entities' expected the value to be one of "
+            . "[auto, always, never], got 'invalid-option' instead."
+        );
+
+        $source  = '<!DOCTYPE html><html><head></head><body></body></html>';
+        $options = [
+            Option::NORMALIZE_HTML_ENTITIES => 'invalid-option',
+        ];
+
+        Document::fromHtml($source, $options);
     }
 }

--- a/tests/Dom/DocumentTest.php
+++ b/tests/Dom/DocumentTest.php
@@ -1486,4 +1486,55 @@ class DocumentTest extends TestCase
         $output = $document->saveHTML();
         $this->assertSimilarMarkup($expected, $output);
     }
+
+    /**
+     * Data for AmpProject\Dom\Document test.
+     *
+     * @return array Data.
+     */
+    public function dataHtmlEntities()
+    {
+        $head = '<head><meta charset="utf-8"></head>';
+
+        return [
+            'prevent_html_entities_from_double_encoding' => [
+                '<!DOCTYPE html><html><head></head><body>'
+                . '<p>Lorem ipsum dolor sit&comma; amet consectetur adipisicing elit&period; Repudiandae maxime accusamus mollitia nobis deleniti&colon; quia laborum iste &amp; reprehenderit&period;</p>'
+                . '</body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body>'
+                . '<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repudiandae maxime accusamus mollitia nobis deleniti: quia laborum iste &amp; reprehenderit.</p>'
+                . '</body></html>',
+                []
+            ],
+            'do_not_filter_entities' => [
+                '<!DOCTYPE html><html><head></head><body>'
+                . '<p>Lorem ipsum dolor sit&comma; amet consectetur</p>'
+                . '</body></html>',
+                '<!DOCTYPE html><html>' . $head . '<body>'
+                . '<p>Lorem ipsum dolor sit&amp;comma; amet consectetur</p>'
+                . '</body></html>',
+                [
+                    Option::FILTER_HTML_ENTITIES => false,
+                ]
+            ],
+        ];
+    }
+
+    /**
+     *
+     * @param string $source   Source content.
+     * @param string $expected Expected target content.
+     * @param array  $options  Options for Document class.
+     *
+     * @dataProvider dataHtmlEntities
+     *
+     * @covers \AmpProject\Dom\Document\Filter\HtmlEntities::beforeLoad()
+     */
+    public function testHtmlEntities($source, $expected, $options)
+    {
+        $document = Document::fromHtml($source, $options);
+        $output   = $document->saveHTML();
+
+        $this->assertEqualMarkup($expected, $output);
+    }
 }

--- a/tests/Dom/OptionsTest.php
+++ b/tests/Dom/OptionsTest.php
@@ -23,10 +23,12 @@ class OptionsTest extends TestCase
     {
         $options        = new Options(Option::DEFAULTS);
         $defaultOptions = [
-            'amp_bind_syntax' => 'auto',
-            'encoding'        => null,
-            'libxml_flags'    => 0,
-            'check_encoding'  => false,
+            'amp_bind_syntax'            => 'auto',
+            'encoding'                   => null,
+            'libxml_flags'               => 0,
+            'check_encoding'             => false,
+            'filter_html_entities'       => 'auto',
+            'filter_html_entities_flags' => ENT_HTML5,
         ];
 
         $this->assertSame($options->toArray(), $defaultOptions);

--- a/tests/Dom/OptionsTest.php
+++ b/tests/Dom/OptionsTest.php
@@ -23,12 +23,12 @@ class OptionsTest extends TestCase
     {
         $options        = new Options(Option::DEFAULTS);
         $defaultOptions = [
-            'amp_bind_syntax'            => 'auto',
-            'encoding'                   => null,
-            'libxml_flags'               => 0,
-            'check_encoding'             => false,
-            'filter_html_entities'       => 'auto',
-            'filter_html_entities_flags' => ENT_HTML5,
+            'amp_bind_syntax'               => 'auto',
+            'encoding'                      => null,
+            'libxml_flags'                  => 0,
+            'check_encoding'                => false,
+            'normalize_html_entities'       => 'auto',
+            'normalize_html_entities_flags' => ENT_HTML5,
         ];
 
         $this->assertSame($options->toArray(), $defaultOptions);


### PR DESCRIPTION
This PR adds a new NormalizeHtmlEntities filter which decode the html entities before it is loaded into the Dom\Document. Fixes #409 