### PR TITLE
Add InvalidOptionValue exception

### DIFF
--- a/src/Exception/InvalidOptionValue.php
+++ b/src/Exception/InvalidOptionValue.php
@@ -2,14 +2,14 @@
 
 namespace AmpProject\Exception;
 
-use InvalidArgumentException;
+use DomainException;
 
 /**
  * Exception thrown when an invalid option value was provided.
  *
  * @package ampproject/amp-toolbox
  */
-final class InvalidOptionValue extends InvalidArgumentException implements AmpException
+final class InvalidOptionValue extends DomainException implements AmpException
 {
     /**
      * Instantiate an InvalidOptionValue exception for an invalid option value.

--- a/src/Exception/InvalidOptionValue.php
+++ b/src/Exception/InvalidOptionValue.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AmpProject\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when an invalid option value was provided.
+ *
+ * @package ampproject/amp-toolbox
+ */
+final class InvalidOptionValue extends InvalidArgumentException implements AmpException
+{
+    /**
+     * Instantiate an InvalidOptionValue exception for an invalid option value.
+     *
+     * @param string        $option   Name of the option.
+     * @param array<string> $accepted Array of acceptable values.
+     * @param string        $actual   Value that was actually provided.
+     * @return self
+     */
+    public static function forValue($option, $accepted, $actual)
+    {
+        $acceptedString = implode(', ', $accepted);
+        $message = "The value for the option '{$option}' expected the value to be one of "
+                   . "[{$acceptedString}], got '{$actual}' instead.";
+
+        return new self($message);
+    }
+}

--- a/tests/Exception/InvalidOptionValueTest.php
+++ b/tests/Exception/InvalidOptionValueTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AmpProject\Exception;
+
+use AmpProject\Tests\TestCase;
+
+/**
+ * Test the InvalidOptionValue exception.
+ *
+ * @covers \AmpProject\Exception\InvalidOptionValue
+ * @package ampproject/amp-toolbox
+ */
+class InvalidOptionValueTest extends TestCase
+{
+    /**
+     * Test throwing the exception for an invalid option value.
+     */
+    public function testThrowingForSpecName()
+    {
+        $this->expectException(InvalidOptionValue::class);
+        $this->expectExceptionMessage(
+            "The value for the option 'optionName' expected the value to be one of "
+            . "[optionA, optionB], got 'invalid' instead."
+        );
+
+        throw InvalidOptionValue::forValue('optionName', ['optionA', 'optionB'], 'invalid');
+    }
+}


### PR DESCRIPTION
This PR adds a new exception class `InvalidOptionValue`. Fixes #454.