### PR TITLE
Add a new simplified table formatter API 

### DIFF
--- a/src/Cli/TableFormatter.php
+++ b/src/Cli/TableFormatter.php
@@ -153,8 +153,8 @@ class TableFormatter
         for ($index = 0; $index < $maxLength; $index++) {
             foreach ($columns as $column => $width) {
                 if ($this->isBorderedTable && $column === 0) {
-                    $output .= ltrim($this->border);
-                    $width = $width - 2;
+                    $output .= $this->border . str_repeat(' ', $this->padding);
+                    $width = $width - strlen($this->border) - $this->padding;
                 }
 
                 if (isset($wrapped[$column][$index])) {
@@ -180,7 +180,7 @@ class TableFormatter
                 }
 
                 if ($this->isBorderedTable && $column === $last) {
-                    $output .= rtrim($this->border);
+                    $output .= str_repeat(' ', $this->padding) . $this->border;
                 }
             }
             $output .= "\n";
@@ -412,7 +412,8 @@ class TableFormatter
      */
     public function formatTable($rows, $headers = [])
     {
-        $this->setBorder(' | ');
+        $this->setBorder('|');
+        $this->setPadding(1);
         $this->setIsBorderedTable(true);
 
         if (! empty($headers)) {
@@ -428,7 +429,7 @@ class TableFormatter
         $columns = array_map(function ($width, $index) {
             // Add extra padding to the first and last columns.
             if ($index === 0 || $index === count($this->tableColumnWidths) - 1) {
-                $width = $width + 2;
+                $width = $width + strlen($this->border) + $this->padding;
             }
 
             return $width;
@@ -436,7 +437,8 @@ class TableFormatter
 
         // For a three column table, we'll have have "| " at start and " |" at the end,
         // and in-between two " | ". So in total "| " + " | " + " | " + " |" = 10 chars.
-        $totalBorderWidth     = 4 + ($numberOfColumns - 1) * 3;
+		$borderCharWidth = strlen($this->border);
+        $totalBorderWidth     = 2 * ($borderCharWidth + $this->padding) + ($numberOfColumns - 1) * ($borderCharWidth + ($this->padding * 2));
         $estimatedColumnWidth = $numberOfColumns * $this->maxColumnWidth;
         $estimatedTotalWidth  = $totalBorderWidth + $estimatedColumnWidth;
 
@@ -459,7 +461,7 @@ class TableFormatter
                 $avrgExtraWidth = floor($extraWidth / count($resizedWidths));
 
                 foreach ($this->tableColumnWidths as $i => &$width) {
-                    if (in_array($width, $resizedWidths)) {
+                    if (in_array($width, $resizedWidths, true)) {
                         $width = $avrg + $avrgExtraWidth;
                         array_shift($resizedWidths);
                         if (empty($resizedWidths)) {
@@ -469,7 +471,7 @@ class TableFormatter
                     }
 
                     if ($i === 0 || $i === $numberOfColumns - 1) {
-                        $width = $width + 2;
+                        $width = $width + strlen($this->border) + $this->padding;
                     }
 
                     $columns[$i] = intval($width);
@@ -552,8 +554,9 @@ class TableFormatter
         $tableRow = explode("\n", $tableRow);
         $firstRow = array_shift($tableRow);
         $firstRow = trim($firstRow);
-        $border   = preg_replace('/[^|]/', '-', $firstRow);
-        $border   = preg_replace('/[|]/', '+', $border);
+		$borderChar = preg_quote($this->border, '/');
+        $border     = preg_replace("/[^{$borderChar}]/", '-', $firstRow);
+        $border     = preg_replace("/[{$borderChar}]/", '+', $border);
 
         return $border;
     }

--- a/src/Cli/TableFormatter.php
+++ b/src/Cli/TableFormatter.php
@@ -26,6 +26,13 @@ class TableFormatter
     protected $border = ' ';
 
     /**
+     * Padding around the border.
+     *
+     * @var int
+     */
+    protected $padding = 0;
+
+    /**
      * The terminal width in characters.
      *
      * Falls back to 74 characters if it cannot be detected.
@@ -104,6 +111,18 @@ class TableFormatter
     }
 
     /**
+     * Set the padding.
+     *
+     * The padding around the border is added to the column widths.
+     *
+     * @param int $padding Padding to set.
+     */
+    public function setPadding($padding)
+    {
+        $this->padding = $padding;
+    }
+
+    /**
      * Width of the terminal in characters.
      *
      * Initially auto-detected, with a fallback of 74 characters.
@@ -176,7 +195,7 @@ class TableFormatter
 
                 // Add border in-between columns.
                 if ($column != $last) {
-                    $output .= $this->border;
+                    $output .= str_repeat(' ', $this->padding) . $this->border . str_repeat(' ', $this->padding);
                 }
 
                 if ($this->isBorderedTable && $column === $last) {
@@ -437,8 +456,10 @@ class TableFormatter
 
         // For a three column table, we'll have have "| " at start and " |" at the end,
         // and in-between two " | ". So in total "| " + " | " + " | " + " |" = 10 chars.
-		$borderCharWidth = strlen($this->border);
-        $totalBorderWidth     = 2 * ($borderCharWidth + $this->padding) + ($numberOfColumns - 1) * ($borderCharWidth + ($this->padding * 2));
+        $borderCharWidth  = strlen($this->border);
+        $totalBorderWidth = 2 * ($borderCharWidth + $this->padding)
+            + ($numberOfColumns - 1)
+            * ($borderCharWidth + ($this->padding * 2));
         $estimatedColumnWidth = $numberOfColumns * $this->maxColumnWidth;
         $estimatedTotalWidth  = $totalBorderWidth + $estimatedColumnWidth;
 
@@ -554,7 +575,7 @@ class TableFormatter
         $tableRow = explode("\n", $tableRow);
         $firstRow = array_shift($tableRow);
         $firstRow = trim($firstRow);
-		$borderChar = preg_quote($this->border, '/');
+        $borderChar = preg_quote($this->border, '/');
         $border     = preg_replace("/[^{$borderChar}]/", '-', $firstRow);
         $border     = preg_replace("/[{$borderChar}]/", '+', $border);
 

--- a/src/Cli/TableFormatter.php
+++ b/src/Cli/TableFormatter.php
@@ -423,14 +423,16 @@ class TableFormatter
             $this->calculateTableColumnWidths($row);
         }
 
-        $paddedWidth      = $this->maxColumnWidth + 2;
         $numberOfColumns  = count($this->tableColumnWidths);
 
-        $columns = array_merge(
-            [$paddedWidth],
-            array_fill(0, $numberOfColumns - 2, $this->maxColumnWidth),
-            [$paddedWidth]
-        );
+        $columns = array_map(function ($width, $index) {
+            // Add extra padding to the first and last columns.
+            if ($index === 0 || $index === count($this->tableColumnWidths) - 1) {
+                $width = $width + 2;
+            }
+
+            return $width;
+        }, $this->tableColumnWidths, array_keys($this->tableColumnWidths));
 
         // For a three column table, we'll have have "| " at start and " |" at the end,
         // and in-between two " | ". So in total "| " + " | " + " | " + " |" = 10 chars.

--- a/tests/Cli/TableFormatterTest.php
+++ b/tests/Cli/TableFormatterTest.php
@@ -142,4 +142,41 @@ class TableFormatterTest extends TestCase
         $result = $tableFormatter->format([5, '*'], [$column1, $column2]);
         $this->assertEquals($expected, $result);
     }
+
+    public function testFormatTable()
+    {
+        $items = [
+            [ 'html', 'HTML', 'Markup Language' ],
+            [ 'css', 'CSS', 'Style Sheet' ],
+            [ 'js', 'JavaScript', 'Programming language' ],
+        ];
+
+        $headers = [ 'Name', 'Title', 'Description' ];
+
+        $tableFormatter = new TableFormatter();
+        $table = $tableFormatter->formatTable( $items, $headers );
+
+        $expected = ""
+            . "+----------------------+----------------------+----------------------+" . "\n"
+            . "| Name                 | Title                | Description          |" . "\n"
+            . "+----------------------+----------------------+----------------------+" . "\n"
+            . "| html                 | HTML                 | Markup Language      |" . "\n"
+            . "| css                  | CSS                  | Style Sheet          |" . "\n"
+            . "| js                   | JavaScript           | Programming language |" . "\n"
+            . "+----------------------+----------------------+----------------------+";
+
+        $this->assertEquals($expected, $table);
+
+        $tableFormatter = new TableFormatter();
+        $table = $tableFormatter->formatTable( $items );
+
+        $expected = ""
+            . "+----------------------+----------------------+----------------------+" . "\n"
+            . "| html                 | HTML                 | Markup Language      |" . "\n"
+            . "| css                  | CSS                  | Style Sheet          |" . "\n"
+            . "| js                   | JavaScript           | Programming language |" . "\n"
+            . "+----------------------+----------------------+----------------------+";
+
+        $this->assertEquals($expected, $table);
+    }
 }

--- a/tests/Cli/TableFormatterTest.php
+++ b/tests/Cli/TableFormatterTest.php
@@ -180,4 +180,74 @@ class TableFormatterTest extends TestCase
         $table = $tableFormatter->formatTable($rows);
         $this->assertEquals($expected, $table);
     }
+
+    public function testFormatTableWithLongText()
+    {
+        $column4 = str_repeat('Column3', 20);
+        $headers = ['Column1', 'Column2', $column4, 'Column4'];
+
+        $item13 = rtrim(str_repeat('item13 ', 20));
+        $rows = [
+            ['item11', 'item12', $item13, 'item14'],
+            ['item21', 'item22', 'item23', 'item24'],
+            ['item31', 'item32', 'item33', 'item34'],
+            ['item41', 'item42', 'item43', 'item44'],
+        ];
+
+        $tableFormatter = new TableFormatter();
+        $tableFormatter->setMaxWidth(100);
+
+        $expected = <<<OUTPUT
+            +---------+---------+------------------------------------------------------------------+-----------+
+            | Column1 | Column2 | Column3Column3Column3Column3Column3Column3Column3Column3Column3C | Column4   |
+            |         |         | olumn3Column3Column3Column3Column3Column3Column3Column3Column3Co |           |
+            |         |         | lumn3Column3                                                     |           |
+            +---------+---------+------------------------------------------------------------------+-----------+
+            | item11  | item12  | item13 item13 item13 item13 item13 item13 item13 item13 item13   | item14    |
+            |         |         | item13 item13 item13 item13 item13 item13 item13 item13 item13   |           |
+            |         |         | item13 item13                                                    |           |
+            | item21  | item22  | item23                                                           | item24    |
+            | item31  | item32  | item33                                                           | item34    |
+            | item41  | item42  | item43                                                           | item44    |
+            +---------+---------+------------------------------------------------------------------+-----------+
+            OUTPUT;
+
+        $table = $tableFormatter->formatTable($rows, $headers);
+        $this->assertEquals($expected, $table);
+
+        $item32 = rtrim(str_repeat('item32 ', 20));
+        $item42 = rtrim(str_repeat('item42 ', 30));
+        $rows = [
+            ['item11', 'item12', 'item13', 'item14'],
+            ['item21', 'item22', 'item23', 'item24'],
+            ['item31', $item32, 'item33', 'item34'],
+            ['item41', $item42, 'item43', 'item44'],
+        ];
+        $tableFormatter = new TableFormatter();
+        $tableFormatter->setMaxWidth(120);
+
+        $expected = <<<OUTPUT
+            +---------+-----------------------------------------------+------------------------------------------------+-----------+
+            | Column1 | Column2                                       | Column3Column3Column3Column3Column3Column3Colu | Column4   |
+            |         |                                               | mn3Column3Column3Column3Column3Column3Column3C |           |
+            |         |                                               | olumn3Column3Column3Column3Column3Column3Colum |           |
+            |         |                                               | n3                                             |           |
+            +---------+-----------------------------------------------+------------------------------------------------+-----------+
+            | item11  | item12                                        | item13                                         | item14    |
+            | item21  | item22                                        | item23                                         | item24    |
+            | item31  | item32 item32 item32 item32 item32 item32     | item33                                         | item34    |
+            |         | item32 item32 item32 item32 item32 item32     |                                                |           |
+            |         | item32 item32 item32 item32 item32 item32     |                                                |           |
+            |         | item32 item32                                 |                                                |           |
+            | item41  | item42 item42 item42 item42 item42 item42     | item43                                         | item44    |
+            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
+            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
+            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
+            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
+            +---------+-----------------------------------------------+------------------------------------------------+-----------+
+            OUTPUT;
+
+        $table = $tableFormatter->formatTable($rows, $headers);
+        $this->assertEquals($expected, $table);
+    }
 }

--- a/tests/Cli/TableFormatterTest.php
+++ b/tests/Cli/TableFormatterTest.php
@@ -156,26 +156,26 @@ class TableFormatterTest extends TestCase
 
         // With headers.
         $expected = <<<OUTPUT
-            +----------------------+----------------------+----------------------+
-            | Name                 | Title                | Description          |
-            +----------------------+----------------------+----------------------+
-            | html                 | HTML                 | Markup Language      |
-            | css                  | CSS                  | Style Sheet          |
-            | js                   | JavaScript           | Programming language |
-            +----------------------+----------------------+----------------------+
-            OUTPUT;
++----------------------+----------------------+----------------------+
+| Name                 | Title                | Description          |
++----------------------+----------------------+----------------------+
+| html                 | HTML                 | Markup Language      |
+| css                  | CSS                  | Style Sheet          |
+| js                   | JavaScript           | Programming language |
++----------------------+----------------------+----------------------+
+OUTPUT;
 
         $table = $tableFormatter->formatTable($rows, $headers);
         $this->assertEquals($expected, $table);
 
         // Without headers.
         $expected = <<<OUTPUT
-            +----------------------+----------------------+----------------------+
-            | html                 | HTML                 | Markup Language      |
-            | css                  | CSS                  | Style Sheet          |
-            | js                   | JavaScript           | Programming language |
-            +----------------------+----------------------+----------------------+
-            OUTPUT;
++----------------------+----------------------+----------------------+
+| html                 | HTML                 | Markup Language      |
+| css                  | CSS                  | Style Sheet          |
+| js                   | JavaScript           | Programming language |
++----------------------+----------------------+----------------------+
+OUTPUT;
 
         $table = $tableFormatter->formatTable($rows);
         $this->assertEquals($expected, $table);
@@ -198,19 +198,19 @@ class TableFormatterTest extends TestCase
         $tableFormatter->setMaxWidth(100);
 
         $expected = <<<OUTPUT
-            +---------+---------+------------------------------------------------------------------+-----------+
-            | Column1 | Column2 | Column3Column3Column3Column3Column3Column3Column3Column3Column3C | Column4   |
-            |         |         | olumn3Column3Column3Column3Column3Column3Column3Column3Column3Co |           |
-            |         |         | lumn3Column3                                                     |           |
-            +---------+---------+------------------------------------------------------------------+-----------+
-            | item11  | item12  | item13 item13 item13 item13 item13 item13 item13 item13 item13   | item14    |
-            |         |         | item13 item13 item13 item13 item13 item13 item13 item13 item13   |           |
-            |         |         | item13 item13                                                    |           |
-            | item21  | item22  | item23                                                           | item24    |
-            | item31  | item32  | item33                                                           | item34    |
-            | item41  | item42  | item43                                                           | item44    |
-            +---------+---------+------------------------------------------------------------------+-----------+
-            OUTPUT;
++---------+---------+------------------------------------------------------------------+-----------+
+| Column1 | Column2 | Column3Column3Column3Column3Column3Column3Column3Column3Column3C | Column4   |
+|         |         | olumn3Column3Column3Column3Column3Column3Column3Column3Column3Co |           |
+|         |         | lumn3Column3                                                     |           |
++---------+---------+------------------------------------------------------------------+-----------+
+| item11  | item12  | item13 item13 item13 item13 item13 item13 item13 item13 item13   | item14    |
+|         |         | item13 item13 item13 item13 item13 item13 item13 item13 item13   |           |
+|         |         | item13 item13                                                    |           |
+| item21  | item22  | item23                                                           | item24    |
+| item31  | item32  | item33                                                           | item34    |
+| item41  | item42  | item43                                                           | item44    |
++---------+---------+------------------------------------------------------------------+-----------+
+OUTPUT;
 
         $table = $tableFormatter->formatTable($rows, $headers);
         $this->assertEquals($expected, $table);
@@ -227,25 +227,25 @@ class TableFormatterTest extends TestCase
         $tableFormatter->setMaxWidth(120);
 
         $expected = <<<OUTPUT
-            +---------+-----------------------------------------------+------------------------------------------------+-----------+
-            | Column1 | Column2                                       | Column3Column3Column3Column3Column3Column3Colu | Column4   |
-            |         |                                               | mn3Column3Column3Column3Column3Column3Column3C |           |
-            |         |                                               | olumn3Column3Column3Column3Column3Column3Colum |           |
-            |         |                                               | n3                                             |           |
-            +---------+-----------------------------------------------+------------------------------------------------+-----------+
-            | item11  | item12                                        | item13                                         | item14    |
-            | item21  | item22                                        | item23                                         | item24    |
-            | item31  | item32 item32 item32 item32 item32 item32     | item33                                         | item34    |
-            |         | item32 item32 item32 item32 item32 item32     |                                                |           |
-            |         | item32 item32 item32 item32 item32 item32     |                                                |           |
-            |         | item32 item32                                 |                                                |           |
-            | item41  | item42 item42 item42 item42 item42 item42     | item43                                         | item44    |
-            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
-            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
-            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
-            |         | item42 item42 item42 item42 item42 item42     |                                                |           |
-            +---------+-----------------------------------------------+------------------------------------------------+-----------+
-            OUTPUT;
++---------+-----------------------------------------------+------------------------------------------------+-----------+
+| Column1 | Column2                                       | Column3Column3Column3Column3Column3Column3Colu | Column4   |
+|         |                                               | mn3Column3Column3Column3Column3Column3Column3C |           |
+|         |                                               | olumn3Column3Column3Column3Column3Column3Colum |           |
+|         |                                               | n3                                             |           |
++---------+-----------------------------------------------+------------------------------------------------+-----------+
+| item11  | item12                                        | item13                                         | item14    |
+| item21  | item22                                        | item23                                         | item24    |
+| item31  | item32 item32 item32 item32 item32 item32     | item33                                         | item34    |
+|         | item32 item32 item32 item32 item32 item32     |                                                |           |
+|         | item32 item32 item32 item32 item32 item32     |                                                |           |
+|         | item32 item32                                 |                                                |           |
+| item41  | item42 item42 item42 item42 item42 item42     | item43                                         | item44    |
+|         | item42 item42 item42 item42 item42 item42     |                                                |           |
+|         | item42 item42 item42 item42 item42 item42     |                                                |           |
+|         | item42 item42 item42 item42 item42 item42     |                                                |           |
+|         | item42 item42 item42 item42 item42 item42     |                                                |           |
++---------+-----------------------------------------------+------------------------------------------------+-----------+
+OUTPUT;
 
         $table = $tableFormatter->formatTable($rows, $headers);
         $this->assertEquals($expected, $table);

--- a/tests/Cli/TableFormatterTest.php
+++ b/tests/Cli/TableFormatterTest.php
@@ -156,13 +156,13 @@ class TableFormatterTest extends TestCase
 
         // With headers.
         $expected = <<<OUTPUT
-+----------------------+----------------------+----------------------+
-| Name                 | Title                | Description          |
-+----------------------+----------------------+----------------------+
-| html                 | HTML                 | Markup Language      |
-| css                  | CSS                  | Style Sheet          |
-| js                   | JavaScript           | Programming language |
-+----------------------+----------------------+----------------------+
++------+------------+----------------------+
+| Name | Title      | Description          |
++------+------------+----------------------+
+| html | HTML       | Markup Language      |
+| css  | CSS        | Style Sheet          |
+| js   | JavaScript | Programming language |
++------+------------+----------------------+
 OUTPUT;
 
         $table = $tableFormatter->formatTable($rows, $headers);
@@ -170,11 +170,11 @@ OUTPUT;
 
         // Without headers.
         $expected = <<<OUTPUT
-+----------------------+----------------------+----------------------+
-| html                 | HTML                 | Markup Language      |
-| css                  | CSS                  | Style Sheet          |
-| js                   | JavaScript           | Programming language |
-+----------------------+----------------------+----------------------+
++------+------------+----------------------+
+| html | HTML       | Markup Language      |
+| css  | CSS        | Style Sheet          |
+| js   | JavaScript | Programming language |
++------+------------+----------------------+
 OUTPUT;
 
         $table = $tableFormatter->formatTable($rows);

--- a/tests/Cli/TableFormatterTest.php
+++ b/tests/Cli/TableFormatterTest.php
@@ -145,38 +145,39 @@ class TableFormatterTest extends TestCase
 
     public function testFormatTable()
     {
-        $items = [
-            [ 'html', 'HTML', 'Markup Language' ],
-            [ 'css', 'CSS', 'Style Sheet' ],
-            [ 'js', 'JavaScript', 'Programming language' ],
+        $headers = ['Name', 'Title', 'Description'];
+        $rows    = [
+            ['html', 'HTML', 'Markup Language'],
+            ['css', 'CSS', 'Style Sheet'],
+            ['js', 'JavaScript', 'Programming language'],
         ];
 
-        $headers = [ 'Name', 'Title', 'Description' ];
-
         $tableFormatter = new TableFormatter();
-        $table = $tableFormatter->formatTable( $items, $headers );
 
-        $expected = ""
-            . "+----------------------+----------------------+----------------------+" . "\n"
-            . "| Name                 | Title                | Description          |" . "\n"
-            . "+----------------------+----------------------+----------------------+" . "\n"
-            . "| html                 | HTML                 | Markup Language      |" . "\n"
-            . "| css                  | CSS                  | Style Sheet          |" . "\n"
-            . "| js                   | JavaScript           | Programming language |" . "\n"
-            . "+----------------------+----------------------+----------------------+";
+        // With headers.
+        $expected = <<<OUTPUT
+            +----------------------+----------------------+----------------------+
+            | Name                 | Title                | Description          |
+            +----------------------+----------------------+----------------------+
+            | html                 | HTML                 | Markup Language      |
+            | css                  | CSS                  | Style Sheet          |
+            | js                   | JavaScript           | Programming language |
+            +----------------------+----------------------+----------------------+
+            OUTPUT;
 
+        $table = $tableFormatter->formatTable($rows, $headers);
         $this->assertEquals($expected, $table);
 
-        $tableFormatter = new TableFormatter();
-        $table = $tableFormatter->formatTable( $items );
+        // Without headers.
+        $expected = <<<OUTPUT
+            +----------------------+----------------------+----------------------+
+            | html                 | HTML                 | Markup Language      |
+            | css                  | CSS                  | Style Sheet          |
+            | js                   | JavaScript           | Programming language |
+            +----------------------+----------------------+----------------------+
+            OUTPUT;
 
-        $expected = ""
-            . "+----------------------+----------------------+----------------------+" . "\n"
-            . "| html                 | HTML                 | Markup Language      |" . "\n"
-            . "| css                  | CSS                  | Style Sheet          |" . "\n"
-            . "| js                   | JavaScript           | Programming language |" . "\n"
-            . "+----------------------+----------------------+----------------------+";
-
+        $table = $tableFormatter->formatTable($rows);
         $this->assertEquals($expected, $table);
     }
 }


### PR DESCRIPTION
This PR adds a new public API to the `TableFormatter` to make it easy to use. With this we will able to format table like this,

```php
$items = [
    [ 'html', 'HTML', 'Markup Language' ],
    [ 'css', 'CSS', 'Style Sheet' ],
    [ 'js', 'JavaScript', 'Programming language' ],
];

$headers = [ 'Name', 'Title', 'Description' ];

// With headers
$tableFormatter = new TableFormatter();
$table = $tableFormatter->formatTable( $items, $headers );

/* output
+------+------------+----------------------+
| Name | Title      | Description          |
+------+------------+----------------------+
| html | HTML       | Markup Language      |
| css  | CSS        | Style Sheet          |
| js   | JavaScript | Programming language |
+------+------------+----------------------+
*/

// Without headers
$tableFormatter = new TableFormatter();
$table = $tableFormatter->formatTable( $items );

/* output
+------+------------+----------------------+
| html | HTML       | Markup Language      |
| css  | CSS        | Style Sheet          |
| js   | JavaScript | Programming language |
+------+------------+----------------------+
*/
```

Closes #453 

### To-do:
- [x] Handle long texts that exceed the width of the terminal.
- [x] Add more tests.
- [x] Add docblocks.
- [x] Fix any PHPCS or PHP Stan issues.