### PR TITLE
Allow Composer plugins to run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,11 @@
     "mck89/peast": "Needed to minify the AMP script."
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "civicrm/composer-downloads-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "extra": {
     "downloads": {


### PR DESCRIPTION
Composer now throws warnings when Composer plugins are being run, and will disable these at a later version for security reasons, unless they have been specifically allowed to run via the `composer.json` file.

This PR allows the plugins to run that we currently use as development dependencies:
- `civicrm/composer-downloads-plugin`
- `dealerdirect/phpcodesniffer-composer-installer`