### PR TITLE
Update action sync local fallback files

### DIFF
--- a/.github/workflows/sync-local-fallback-files.yml
+++ b/.github/workflows/sync-local-fallback-files.yml
@@ -93,4 +93,4 @@ jobs:
           pr_title: Sync local fallback files
           pr_body: ${{ steps.body.outputs.text }}
           pr_reviewer: schlessera
-          pr_label: SSR,automerge
+          pr_label: SSR

--- a/.github/workflows/sync-local-fallback-files.yml
+++ b/.github/workflows/sync-local-fallback-files.yml
@@ -1,8 +1,8 @@
 name: Sync runtime local fallback files
 on:
   schedule:
-    # https://crontab.guru/every-night-at-midnight
-    - cron: 0 0 * * *
+    # https://crontab.guru/once-a-week
+    - cron: 0 0 * * 0
 
 jobs:
   sync-local-fallback-files:


### PR DESCRIPTION
Currently the `Sync runtime local fallback files` workflow creates a PR with a label automerge. But the problem is, GitHub does not trigger the GitHub Checks for this new PR. And after that the `Automatic Merge` workflow merges this new PR since it contains the `automerge` label.

As a temporary solution this PR removes the `automerge` label from the sync fallback workflow to skip merging the PR without doing the GH checks. Additionally the workflow cron time is changed to run once in a week instead of daily.