### PR TITLE
Implement SSR for amp-audio

### DIFF
--- a/src/Optimizer/Error/CannotRemoveBoilerplate.php
+++ b/src/Optimizer/Error/CannotRemoveBoilerplate.php
@@ -22,8 +22,6 @@ final class CannotRemoveBoilerplate implements Error
                                           . 'attribute produced an error: ';
     const RENDER_DELAYING_SCRIPT_STRING = 'Cannot remove boilerplate because the document contains a render-delaying '
                                           . 'extension: ';
-    const AMP_AUDIO_STRING              = 'Cannot remove boilerplate because the document contains an extension that '
-                                          . 'needs to know the dimensions of the browser: ';
     const UNSUPPORTED_LAYOUT_STRING     = 'Cannot remove boilerplate because of an unsupported layout: ';
 
     /**
@@ -57,17 +55,6 @@ final class CannotRemoveBoilerplate implements Error
     public static function fromAmpExperiment(Element $element)
     {
         return new self(self::RENDER_DELAYING_SCRIPT_STRING . $element->tagName);
-    }
-
-    /**
-     * Instantiate a CannotRemoveBoilerplate object for an amp-audio element.
-     *
-     * @param Element $element amp-audio element.
-     * @return self
-     */
-    public static function fromAmpAudio(Element $element)
-    {
-        return new self(self::AMP_AUDIO_STRING . new ElementDump($element));
     }
 
     /**

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -142,6 +142,7 @@ final class ServerSideRendering implements Transformer
             if ($ampElement->tagName === Extension::AUDIO) {
                 $errors->add(Error\CannotRemoveBoilerplate::fromAmpAudio($ampElement));
                 $canRemoveBoilerplate = false;
+                $this->ssrAmpAudio($document, $ampElement);
             }
 
             /*
@@ -1059,5 +1060,29 @@ final class ServerSideRendering implements Transformer
         }
 
         return abs($number) < self::FLOATING_POINT_EPSILON;
+    }
+
+    /**
+     * Server-side rendering of an amp-audio element.
+     *
+     * @param Document $document DOM document to apply the transformations to.
+     * @param Element  $element  Element to adapt.
+     */
+    private function ssrAmpAudio(Document $document, Element $element)
+    {
+        // Check if we already have a SSR-ed audio element.
+        if ($element->hasChildNodes()) {
+            foreach ($element->childNodes as $childNode) {
+                if ($childNode instanceof Element && $childNode->tagName === Tag::AUDIO) {
+                    return;
+                }
+            }
+        }
+
+        $audio = $document->createElement(Tag::AUDIO);
+        $audio->setAttribute(Attribute::CONTROLS, '');
+        $audio->addInlineStyle('width:100%');
+
+        $element->appendChild($audio);
     }
 }

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -1080,7 +1080,7 @@ final class ServerSideRendering implements Transformer
         }
 
         $audio = $document->createElement(Tag::AUDIO);
-        $audio->setAttribute(Attribute::CONTROLS, '');
+        $audio->setAttribute($document->createAttributeNode(Attribute::CONTROLS));
         $audio->addInlineStyle('width:100%');
 
         $element->appendChild($audio);

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -1079,7 +1079,7 @@ final class ServerSideRendering implements Transformer
         $audio    = $document->createElement(Tag::AUDIO);
         $controls = $document->createAttribute(Attribute::CONTROLS);
 
-        $audio->appendChild($controls);
+        $audio->setAttributeNode($controls);
         $element->appendChild($audio);
     }
 }

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -127,22 +127,20 @@ final class ServerSideRendering implements Transformer
             }
 
             /*
+             * Server-side rendering of an amp-audio element.
+             */
+            if ($ampElement->tagName === Extension::AUDIO) {
+                $this->ssrAmpAudio($document, $ampElement);
+                continue;
+            }
+
+            /*
              * amp-experiment is a render delaying extension iff the tag is used in the doc. We check for that here
              * rather than checking for the existence of the amp-experiment script in IsRenderDelayingExtension below.
              */
             if ($ampElement->tagName === Extension::EXPERIMENT && $this->isAmpExperimentUsed($ampElement)) {
                 $errors->add(Error\CannotRemoveBoilerplate::fromAmpExperiment($ampElement));
                 $canRemoveBoilerplate = false;
-            }
-
-            /*
-             * amp-audio requires knowing the dimensions of the browser. Do not remove the boilerplate or apply layout
-             * if amp-audio is present in the document.
-             */
-            if ($ampElement->tagName === Extension::AUDIO) {
-                $errors->add(Error\CannotRemoveBoilerplate::fromAmpAudio($ampElement));
-                $canRemoveBoilerplate = false;
-                $this->ssrAmpAudio($document, $ampElement);
             }
 
             /*

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -1079,10 +1079,10 @@ final class ServerSideRendering implements Transformer
             }
         }
 
-        $audio = $document->createElement(Tag::AUDIO);
-        $audio->setAttribute($document->createAttributeNode(Attribute::CONTROLS));
-        $audio->addInlineStyle('width:100%');
+        $audio    = $document->createElement(Tag::AUDIO);
+        $controls = $document->createAttribute(Attribute::CONTROLS);
 
+        $audio->appendChild($controls);
         $element->appendChild($audio);
     }
 }

--- a/src/Optimizer/Transformer/ServerSideRendering.php
+++ b/src/Optimizer/Transformer/ServerSideRendering.php
@@ -131,7 +131,6 @@ final class ServerSideRendering implements Transformer
              */
             if ($ampElement->tagName === Extension::AUDIO) {
                 $this->ssrAmpAudio($document, $ampElement);
-                continue;
             }
 
             /*

--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -48,6 +48,8 @@ final class SpecTest extends TestCase
         'ReorderHead - preserves_amp_custom_style_order' => 'see https://github.com/ampproject/amp-toolbox/issues/604',
 
         'MinifyHtml - minifies_inline_amp-script'          => 'see https://github.com/ampproject/amp-toolbox-php/issues/260',
+
+        'ServerSideRendering - does_not_transform_amp_audio' => 'The amp-toolbox needs to implement SSR amp-audio',
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -132,14 +132,7 @@ final class ServerSideRenderingTest extends TestCase
 
             'amp-audio' => [
                 $input('<amp-audio></amp-audio>'),
-                $expectWithBoilerplate('<amp-audio><audio controls></audio></amp-audio>'),
-                [
-                    Error\CannotRemoveBoilerplate::fromAmpAudio(
-                        Document::fromHtmlFragment(
-                            '<amp-audio></amp-audio>'
-                        )->body->firstChild
-                    ),
-                ],
+                $expectWithoutBoilerplate('<amp-audio><audio controls></audio></amp-audio>'),
             ],
 
             'amp-experiment is non-empty' => [
@@ -329,14 +322,7 @@ final class ServerSideRenderingTest extends TestCase
 
             'server side render amp-audio' => [
                 $input('<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'),
-                $expectWithBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>'),
-                [
-                    Error\CannotRemoveBoilerplate::fromAmpAudio(
-                        Document::fromHtmlFragment(
-                            '<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'
-                        )->body->firstChild
-                    ),
-                ],
+                $expectWithoutBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>'),
             ],
 
             'ssr amp-audio appends audio element' => [
@@ -345,21 +331,12 @@ final class ServerSideRenderingTest extends TestCase
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
                     . '</amp-audio>'
                 ),
-                $expectWithBoilerplate(
+                $expectWithoutBoilerplate(
                     '<amp-audio src="http://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
                         . '<audio controls></audio>'
                     . '</amp-audio>'
                 ),
-                [
-                    Error\CannotRemoveBoilerplate::fromAmpAudio(
-                        Document::fromHtmlFragment(
-                            '<amp-audio src="http://example.com/audio.mp3" width="300">'
-                                . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                            . '</amp-audio>'
-                        )->body->firstChild
-                    ),
-                ],
             ],
 
             'skip ssr amp-audio if audio child node is present' => [
@@ -369,22 +346,12 @@ final class ServerSideRenderingTest extends TestCase
                         . '<audio controls src="http://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
-                $expectWithBoilerplate(
+                $expectWithoutBoilerplate(
                     '<amp-audio src="http://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
                         . '<audio controls src="http://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
-                [
-                    Error\CannotRemoveBoilerplate::fromAmpAudio(
-                        Document::fromHtmlFragment(
-                            '<amp-audio src="http://example.com/audio.mp3" width="300">'
-                                . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                                . '<audio controls src="http://example.com/audio.mp3"></audio>'
-                            . '</amp-audio>'
-                        )->body->firstChild
-                    ),
-                ],
             ]
         ];
     }

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -132,7 +132,7 @@ final class ServerSideRenderingTest extends TestCase
 
             'amp-audio' => [
                 $input('<amp-audio></amp-audio>'),
-                $expectWithBoilerplate('<amp-audio></amp-audio>'),
+                $expectWithBoilerplate('<amp-audio><audio controls style="width:100%;"></audio></amp-audio>'),
                 [
                     Error\CannotRemoveBoilerplate::fromAmpAudio(
                         Document::fromHtmlFragment(
@@ -326,6 +326,66 @@ final class ServerSideRenderingTest extends TestCase
                 $input('<amp-ad type="doubleclick" data-slot="/6355419/Travel" layout="fluid" height="fluid" width="300"></amp-ad>'),
                 $expectWithoutBoilerplate('<amp-ad class="i-amphtml-layout-fluid i-amphtml-layout-awaiting-size" data-slot="/6355419/Travel" height="fluid" width="300" i-amphtml-layout="fluid" layout="fluid" style="width:100%;height:0;" type="doubleclick"></amp-ad>'),
             ],
+
+            'server side render amp-audio' => [
+                $input('<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'),
+                $expectWithBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls style="width:100%;"></audio></amp-audio>'),
+                [
+                    Error\CannotRemoveBoilerplate::fromAmpAudio(
+                        Document::fromHtmlFragment(
+                            '<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'
+                        )->body->firstChild
+                    ),
+                ],
+            ],
+
+            'ssr amp-audio appends audio element' => [
+                $input(
+                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                        . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                    . '</amp-audio>'
+                ),
+                $expectWithBoilerplate(
+                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                        . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                        . '<audio controls style="width:100%;"></audio>'
+                    . '</amp-audio>'
+                ),
+                [
+                    Error\CannotRemoveBoilerplate::fromAmpAudio(
+                        Document::fromHtmlFragment(
+                            '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                                . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                            . '</amp-audio>'
+                        )->body->firstChild
+                    ),
+                ],
+            ],
+
+            'skip ssr amp-audio if audio child node is present' => [
+                $input(
+                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                        . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                        . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                    . '</amp-audio>'
+                ),
+                $expectWithBoilerplate(
+                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                        . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                        . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                    . '</amp-audio>'
+                ),
+                [
+                    Error\CannotRemoveBoilerplate::fromAmpAudio(
+                        Document::fromHtmlFragment(
+                            '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                                . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
+                                . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                            . '</amp-audio>'
+                        )->body->firstChild
+                    ),
+                ],
+            ]
         ];
     }
 

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -132,7 +132,7 @@ final class ServerSideRenderingTest extends TestCase
 
             'amp-audio' => [
                 $input('<amp-audio></amp-audio>'),
-                $expectWithBoilerplate('<amp-audio><audio controls style="width:100%;"></audio></amp-audio>'),
+                $expectWithBoilerplate('<amp-audio><audio controls></audio></amp-audio>'),
                 [
                     Error\CannotRemoveBoilerplate::fromAmpAudio(
                         Document::fromHtmlFragment(
@@ -329,7 +329,7 @@ final class ServerSideRenderingTest extends TestCase
 
             'server side render amp-audio' => [
                 $input('<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'),
-                $expectWithBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls style="width:100%;"></audio></amp-audio>'),
+                $expectWithBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>'),
                 [
                     Error\CannotRemoveBoilerplate::fromAmpAudio(
                         Document::fromHtmlFragment(
@@ -348,7 +348,7 @@ final class ServerSideRenderingTest extends TestCase
                 $expectWithBoilerplate(
                     '<amp-audio src="http://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                        . '<audio controls style="width:100%;"></audio>'
+                        . '<audio controls></audio>'
                     . '</amp-audio>'
                 ),
                 [
@@ -366,13 +366,13 @@ final class ServerSideRenderingTest extends TestCase
                 $input(
                     '<amp-audio src="http://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                        . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                        . '<audio controls src="http://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
                 $expectWithBoilerplate(
                     '<amp-audio src="http://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                        . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                        . '<audio controls src="http://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
                 [
@@ -380,7 +380,7 @@ final class ServerSideRenderingTest extends TestCase
                         Document::fromHtmlFragment(
                             '<amp-audio src="http://example.com/audio.mp3" width="300">'
                                 . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                                . '<audio controls="" style="width: 100%" src="http://example.com/audio.mp3"></audio>'
+                                . '<audio controls src="http://example.com/audio.mp3"></audio>'
                             . '</amp-audio>'
                         )->body->firstChild
                     ),


### PR DESCRIPTION
Fixes #518 

This PR add the SSR support for amp-audio extension. It simply adds `<audio controls style="width: 100%"></audio>` element if amp-audio extension is present.