### PR TITLE
Fix PHPStan analysis errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,12 +10,12 @@ parameters:
 	ignoreErrors:
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
 		- '#^Parameter \#1 (\$exception_handler|\$callback) of function set_exception_handler expects#'
-		- '#^@readonly property AmpProject\\FakeEnum::\$key is assigned outside of the constructor.$#'
 
 		# @see https://github.com/phpstan/phpstan/issues/5655
 		- '#^PHPDoc tag @var for constant (?:.*) with type array(?:.*) is not subtype of value array(?:.*)\.$#'
 	excludePaths:
 		analyse:
+			- src/FakeEnum.php
 			- src/Validator/Context.php
 			- src/Validator/ExtensionsContext.php
 			- src/Validator/ValidateTagResult.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,9 +8,9 @@ parameters:
 		- include/
 		- src/
 	ignoreErrors:
-		- '#^Unsafe usage of new static\(\).$#'
 		- '#^PHPDoc tag @throws with type AmpProject\\Exception\\FailedRemoteRequest is not subtype of Throwable$#'
 		- '#^Parameter \#1 (\$exception_handler|\$callback) of function set_exception_handler expects#'
+		- '#^@readonly property AmpProject\\FakeEnum::\$key is assigned outside of the constructor.$#'
 
 		# @see https://github.com/phpstan/phpstan/issues/5655
 		- '#^PHPDoc tag @var for constant (?:.*) with type array(?:.*) is not subtype of value array(?:.*)\.$#'

--- a/src/Dom/Document/Filter/DoctypeNode.php
+++ b/src/Dom/Document/Filter/DoctypeNode.php
@@ -22,7 +22,7 @@ final class DoctypeNode implements BeforeLoadFilter, AfterSaveFilter
     /**
      * Regex replacement template for securing the doctype node.
      *
-     * @var string.
+     * @var string
      */
     const HTML_SECURE_DOCTYPE_REPLACEMENT_TEMPLATE = '\1!--amp-\3\4-->';
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -186,7 +186,7 @@ interface Extension
     /**
      * Prefix of an AMP extension.
      *
-     * @var string.
+     * @var string
      */
     const PREFIX = 'amp-';
 }

--- a/src/Optimizer/Configuration/OptimizeHeroImagesConfiguration.php
+++ b/src/Optimizer/Configuration/OptimizeHeroImagesConfiguration.php
@@ -24,7 +24,7 @@ final class OptimizeHeroImagesConfiguration extends BaseTransformerConfiguration
      *
      * An empty string signifies that no backup is available.
      *
-     * @var string.
+     * @var string
      */
     const INLINE_STYLE_BACKUP_ATTRIBUTE = 'inlineStyleBackupAttribute';
 

--- a/src/Optimizer/Configuration/PreloadHeroImageConfiguration.php
+++ b/src/Optimizer/Configuration/PreloadHeroImageConfiguration.php
@@ -25,7 +25,7 @@ final class PreloadHeroImageConfiguration extends BaseTransformerConfiguration
      *
      * An empty string signifies that no backup is available.
      *
-     * @var string.
+     * @var string
      */
     const INLINE_STYLE_BACKUP_ATTRIBUTE = 'inlineStyleBackupAttribute';
 

--- a/src/Optimizer/CssRule.php
+++ b/src/Optimizer/CssRule.php
@@ -26,7 +26,7 @@ final class CssRule
      *
      * Use applyId() to finalize the CSS rule.
      *
-     * @var string.
+     * @var string
      */
     const ID_PLACEHOLDER = '__ID__';
 


### PR DESCRIPTION
PHPStan has added some new rules in 1.7.x that trigger some errors. This PR fixes those issues.  

I've added `src/FakeEnum.php` in PHPStan ignore list because it causes these errors,
```
 ------ --------------------------------------------------------------------------------------
  Line   src/FakeEnum.php
 ------ --------------------------------------------------------------------------------------
  60     @readonly property cannot have a default value.
  68     @readonly property cannot have a default value.
  105    @readonly property AmpProject\FakeEnum::$key is assigned outside of the constructor.
```
We can add a rule in `ignoreErrors` in `phpstan.neon.dist` to ignore the last error. But if we add a rule to ignore the first two errors, it'll apply to all php files. Since FakeEnum class is a 3rd party library file(from myclabs/php-enum package), that is why I believe it is safe to ignore the PHPStan analysis for this file.
