### PR TITLE
Re-enable the Spec tests for server side rendered amp-audio

### DIFF
--- a/tests/Optimizer/SpecTest.php
+++ b/tests/Optimizer/SpecTest.php
@@ -48,8 +48,6 @@ final class SpecTest extends TestCase
         'ReorderHead - preserves_amp_custom_style_order' => 'see https://github.com/ampproject/amp-toolbox/issues/604',
 
         'MinifyHtml - minifies_inline_amp-script'          => 'see https://github.com/ampproject/amp-toolbox-php/issues/260',
-
-        'ServerSideRendering - does_not_transform_amp_audio' => 'The amp-toolbox needs to implement SSR amp-audio',
     ];
 
     const CLASS_SKIP_TEST = '__SKIP__';

--- a/tests/Optimizer/Transformer/ServerSideRenderingTest.php
+++ b/tests/Optimizer/Transformer/ServerSideRenderingTest.php
@@ -321,18 +321,18 @@ final class ServerSideRenderingTest extends TestCase
             ],
 
             'server side render amp-audio' => [
-                $input('<amp-audio src="http://example.com/audio.mp3" width="300"></amp-audio>'),
-                $expectWithoutBoilerplate('<amp-audio src="http://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>'),
+                $input('<amp-audio src="https://example.com/audio.mp3" width="300"></amp-audio>'),
+                $expectWithoutBoilerplate('<amp-audio src="https://example.com/audio.mp3" width="300"><audio controls></audio></amp-audio>'),
             ],
 
             'ssr amp-audio appends audio element' => [
                 $input(
-                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                    '<amp-audio src="https://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
                     . '</amp-audio>'
                 ),
                 $expectWithoutBoilerplate(
-                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                    '<amp-audio src="https://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
                         . '<audio controls></audio>'
                     . '</amp-audio>'
@@ -341,15 +341,15 @@ final class ServerSideRenderingTest extends TestCase
 
             'skip ssr amp-audio if audio child node is present' => [
                 $input(
-                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                    '<amp-audio src="https://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                        . '<audio controls src="http://example.com/audio.mp3"></audio>'
+                        . '<audio controls src="https://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
                 $expectWithoutBoilerplate(
-                    '<amp-audio src="http://example.com/audio.mp3" width="300">'
+                    '<amp-audio src="https://example.com/audio.mp3" width="300">'
                         . '<div fallback="">Your browser doesn’t support HTML5 audio</div>'
-                        . '<audio controls src="http://example.com/audio.mp3"></audio>'
+                        . '<audio controls src="https://example.com/audio.mp3"></audio>'
                     . '</amp-audio>'
                 ),
             ]


### PR DESCRIPTION
The spec test for SSR amp-audio was disable in [PR #523 ](https://github.com/ampproject/amp-toolbox-php/pull/523/files#diff-9e9b60aa021b2202b044d2d9820e201ee6d94b12ae0f8c960f5316183c5b5d12R52). amp-toolbox has the implementation now and we have already synced up the spec tests. So, this PR re-enables the spec test for SSR amp-audio.