### PR TITLE
Cache only valid responses

### DIFF
--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -132,7 +132,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
             $curlErrno = curl_errno($curlHandle);
             curl_close($curlHandle);
 
-            if ($body === false) {
+            if ($body === false || $status < 200 || $status >= 300) {
                 if (! $retriesLeft || in_array($curlErrno, self::RETRYABLE_ERROR_CODES, true) === false) {
                     if (! empty($status) && is_numeric($status)) {
                         throw FailedToGetFromRemoteUrl::withHttpStatus($url, (int) $status);

--- a/src/RemoteRequest/StubbedRemoteGetRequest.php
+++ b/src/RemoteRequest/StubbedRemoteGetRequest.php
@@ -45,6 +45,7 @@ final class StubbedRemoteGetRequest implements RemoteGetRequest
             throw new LogicException("Trying to stub a remote request for an unknown URL: {$url}.");
         }
 
-        return new RemoteGetRequestResponse($this->argumentMap[$url]);
+        $args = $this->argumentMap[$url];
+        return new RemoteGetRequestResponse($args['body'], [], isset($args['status']) ? $args['status'] : 200);
     }
 }

--- a/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
+++ b/src/RemoteRequest/TemporaryFileCachedRemoteGetRequest.php
@@ -141,6 +141,11 @@ final class TemporaryFileCachedRemoteGetRequest implements RemoteGetRequest
      */
     private function cacheResponse($url, Response $response)
     {
+        $statusCode = $response->getStatusCode();
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return;
+        }
+
         file_put_contents($this->getTemporaryFilePath($url), serialize($response));
     }
 

--- a/tests/RemoteRequest/StubbedRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/StubbedRemoteGetRequestTest.php
@@ -17,7 +17,7 @@ class StubbedRemoteGetRequestTest extends TestCase
     {
         $stubbedRequest = new StubbedRemoteGetRequest(
             [
-                'https://example.com/stubbed-file' => 'stubbed response',
+                'https://example.com/stubbed-file' => ['body' => 'stubbed response'],
             ]
         );
 
@@ -32,7 +32,7 @@ class StubbedRemoteGetRequestTest extends TestCase
     {
         $stubbedRequest = new StubbedRemoteGetRequest(
             [
-                'https://example.com/stubbed-file' => 'stubbed response',
+                'https://example.com/stubbed-file' => ['body' => 'stubbed response'],
             ]
         );
 

--- a/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
@@ -113,6 +113,24 @@ class TemporaryFileCachedRemoteGetRequestTest extends TestCase
     }
 
     /**
+     * Test that errors do not get cached.
+     */
+    public function testCacheOnlyValidRepsonses()
+    {
+        $unknownUrl = 'https://cdn.ampproject.com/non-existant.really.not.html';
+
+        $tmpDirectory = vfsStream::url(self::DIRECTORY_NAME);
+        $cachedRequest = new TemporaryFileCachedRemoteGetRequest(
+            new StubbedRemoteGetRequest([$unknownUrl => ['body' => '404 content', 'status' => 404]]),
+            $tmpDirectory
+        );
+
+        $cachedRequest->get($unknownUrl);
+
+        $this->assertFileDoesNotExist($tmpDirectory . DIRECTORY_SEPARATOR . TemporaryFileCachedRemoteGetRequest::CACHED_FILE_PREFIX . md5($unknownUrl));
+    }
+
+    /**
      * Get the request class instance to test against.
      *
      * @return TemporaryFileCachedRemoteGetRequest Request object instance to test against.

--- a/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/TemporaryFileCachedRemoteGetRequestTest.php
@@ -56,7 +56,7 @@ class TemporaryFileCachedRemoteGetRequestTest extends TestCase
 
         $urls            = array_keys(TestMarkup::STUBBED_REMOTE_REQUESTS);
         $url             = $urls[0];
-        $stubbedResponse = TestMarkup::STUBBED_REMOTE_REQUESTS[$url];
+        $stubbedResponse = TestMarkup::STUBBED_REMOTE_REQUESTS[$url]['body'];
 
         $filename = TemporaryFileCachedRemoteGetRequest::CACHED_FILE_PREFIX . md5($url);
         $file     = vfsStream::url(self::DIRECTORY_NAME . "/{$filename}");

--- a/tests/RuntimeVersionTest.php
+++ b/tests/RuntimeVersionTest.php
@@ -20,8 +20,8 @@ class RuntimeVersionTest extends TestCase
      * @var array
      */
     const STUBBED_REMOTE_REQUESTS = [
-        'https://cdn.ampproject.org/rtv/metadata' => '{"ampRuntimeVersion":"012345678900000","ampCssUrl":"https://cdn.ampproject.org/rtv/012345678900000/v0.css","canaryPercentage":"0.1","diversions":["023456789000000","034567890100000","045678901200000"]}',
-        'https://cdn.ampproject.org/v0.css'       => '/* v0.css */',
+        'https://cdn.ampproject.org/rtv/metadata' => ['body' => '{"ampRuntimeVersion":"012345678900000","ampCssUrl":"https://cdn.ampproject.org/rtv/012345678900000/v0.css","canaryPercentage":"0.1","diversions":["023456789000000","034567890100000","045678901200000"]}'],
+        'https://cdn.ampproject.org/v0.css'       => ['body' => '/* v0.css */'],
     ];
 
     /**

--- a/tests/src/TestMarkup.php
+++ b/tests/src/TestMarkup.php
@@ -21,10 +21,10 @@ final class TestMarkup
      * @var array
      */
     const STUBBED_REMOTE_REQUESTS = [
-        'https://cdn.ampproject.org/rtv/metadata'               => '{"ampRuntimeVersion":"012345678900000","ampCssUrl":"https://cdn.ampproject.org/rtv/012345678900000/v0.css","canaryPercentage":"0.1","diversions":["023456789000000","034567890100000","045678901200000"]}',
-        'https://cdn.ampproject.org/v0.css'                     => '/* v0.css */',
-        'https://cdn.ampproject.org/rtv/012345678900000/v0.css' => '/* 012345678900000/v0.css */',
-        'https://cdn.ampproject.org/rtv/012345678901234/v0.css' => '/* 012345678901234/v0.css */',
+        'https://cdn.ampproject.org/rtv/metadata'               => ['body' => '{"ampRuntimeVersion":"012345678900000","ampCssUrl":"https://cdn.ampproject.org/rtv/012345678900000/v0.css","canaryPercentage":"0.1","diversions":["023456789000000","034567890100000","045678901200000"]}'],
+        'https://cdn.ampproject.org/v0.css'                     => ['body' => '/* v0.css */'],
+        'https://cdn.ampproject.org/rtv/012345678900000/v0.css' => ['body' => '/* 012345678900000/v0.css */'],
+        'https://cdn.ampproject.org/rtv/012345678901234/v0.css' => ['body' => '/* 012345678901234/v0.css */'],
     ];
 
     // Doctype is the doctype expected for AMP documents.


### PR DESCRIPTION
Hi!

Recently we discovered that some requests to fetch the metadata failed, but were cached regardless of the status code. This PR adds a guard, that only valid responses are cached.

This fixes #530 