### PR TITLE
Set CURLOPT_FAILONERROR to get the correct curl error code

### DIFF
--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -36,7 +36,6 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
     const RETRYABLE_ERROR_CODES = [
         CURLE_COULDNT_RESOLVE_HOST,
         CURLE_COULDNT_CONNECT,
-        CURLE_HTTP_NOT_FOUND,
         CURLE_READ_ERROR,
         CURLE_OPERATION_TIMEOUTED,
         CURLE_HTTP_POST_ERROR,

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -107,6 +107,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? 1 : 0);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);
             curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);
             curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, $this->timeout);
             curl_setopt($curlHandle, CURLOPT_TIMEOUT, $this->timeout);
 


### PR DESCRIPTION
Otherwise Client Errors (>= 400) return curl error code 0. In case of 404 errors (CURLE_HTTP_NOT_FOUND) it would return 0, instead of 22. See [CURLOPT_FAILONERROR](https://github.com/curl/curl/blob/5ccddf64398c1186deb5769dac086d738e150e09/docs/libcurl/opts/CURLOPT_FAILONERROR.3#L35-L37).

Before this change, 404 errors won't be retried, because `in_array($curlErrno, self::RETRYABLE_ERROR_CODES, true) === false` evaluated to `true`, hence throwing an exception.

This is one puzzle piece from #530 

Btw. to make it clear: It is still a mystery why we sometimes receive 404s from `https://cdn.ampproject.org/rtv/metadata`. This must be something on the server side.. After this PR we still get 404s, but these are hidden.