### PR TITLE
Fix PHPStan errors

### DIFF
--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -108,7 +108,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
             curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, true);
-            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? true : false);
+            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);
             curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -108,7 +108,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
             curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, true);
-            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? 1 : false);
+            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? true : false);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);
             curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -108,7 +108,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
             curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, true);
-            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? 1 : 0);
+            curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? 1 : false);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);
             curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($curlHandle, CURLOPT_FAILONERROR, true);

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -107,6 +107,7 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
             $curlHandle = curl_init();
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
+            curl_setopt($curlHandle, CURLOPT_HEADER, false);
             curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -6,6 +6,7 @@ use AmpProject\Exception\FailedRemoteRequest;
 use AmpProject\Exception\FailedToGetFromRemoteUrl;
 use AmpProject\RemoteGetRequest;
 use AmpProject\Response;
+use AmpProject\Exception\FailedToParseUrl;
 
 /**
  * Remote request transport using cURL.
@@ -97,6 +98,11 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
     public function get($url, $headers = [])
     {
         $retriesLeft = $this->retries;
+
+        if (! is_string($url) || empty($url)) {
+            throw FailedToGetFromRemoteUrl::withException($url, FailedToParseUrl::forUrl($url));
+        }
+
         do {
             $curlHandle = curl_init();
 

--- a/src/RemoteRequest/CurlRemoteGetRequest.php
+++ b/src/RemoteRequest/CurlRemoteGetRequest.php
@@ -107,7 +107,6 @@ final class CurlRemoteGetRequest implements RemoteGetRequest
             $curlHandle = curl_init();
 
             curl_setopt($curlHandle, CURLOPT_URL, $url);
-            curl_setopt($curlHandle, CURLOPT_HEADER, 0);
             curl_setopt($curlHandle, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, $this->sslVerify ? 1 : 0);
             curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, $this->sslVerify ? 2 : 0);

--- a/tests/RemoteRequest/CurlRemoteGetRequestTest.php
+++ b/tests/RemoteRequest/CurlRemoteGetRequestTest.php
@@ -3,6 +3,7 @@
 namespace AmpProject\RemoteRequest;
 
 use AmpProject\RemoteGetRequest;
+use AmpProject\Exception\FailedToGetFromRemoteUrl;
 use AmpProject\Tests\TestCase;
 
 /**
@@ -18,5 +19,21 @@ class CurlRemoteGetRequestTest extends TestCase
         $curlRequest = new CurlRemoteGetRequest(false, -1, -1);
         $this->assertInstanceOf(RemoteGetRequest::class, $curlRequest);
         $this->assertInstanceOf(CurlRemoteGetRequest::class, $curlRequest);
+    }
+
+    /**
+     * @covers ::get()
+     */
+    public function testGet()
+    {
+        $curlRequest = new CurlRemoteGetRequest(false);
+
+        // When passed url is not string, it should throw exception.
+        $this->expectException(FailedToGetFromRemoteUrl::class);
+        $curlRequest->get(123);
+
+        // When passed url is empty string, it should throw exception.
+        $this->expectException(FailedToGetFromRemoteUrl::class);
+        $curlRequest->get('');
     }
 }


### PR DESCRIPTION
This PR aims to fix PHPStan errors introduced as a part of https://github.com/ampproject/amp-toolbox-php/pull/534. See the [`error log`](https://github.com/ampproject/amp-toolbox-php/actions/runs/3277984591/jobs/5395871464#step:7:14).

![image](https://user-images.githubusercontent.com/54371619/196605689-6839f0cf-688e-4952-9bc6-4984226b666a.png)


## Tasks Done
- Add a guard to check if passed `$url` in `CurlRemoteGetRequest::get` is a `non-empty-string`.
- Remove `curl_setopt($curlHandle, CURLOPT_HEADER, 0);` as we need to pass `true` if we want to enable this option. ([Ref](https://www.php.net/manual/en/function.curl-setopt.php#:~:text=CURLOPT_HEADER,in%20the%20output.)).
- Update the `CURLOPT_SSL_VERIFYPEER` value as we need to pass `false` if we want to disable it. ([Ref](https://www.php.net/manual/en/function.curl-setopt.php#:~:text=CURLOPT_SSL_VERIFYPEER,the%20peer%27s%20certificate.)).