### PR TITLE
Improve PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.1', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6']
+        php: ['8.3', '8.1', '8.0', '7.4']
         coverage: [false]
         random: [false]
         include:
-          - php: '8.0'
+          - php: '8.2'
             coverage: true
-          - php: '8.0'
+          - php: '8.2'
             random: true
-          - php: '8.3'
+          - php: '8.4'
             experimental: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
   "license": "Apache-2.0",
   "require": {
-    "php": "^5.6 || ^7.0 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-dom": "*",
     "ext-filter": "*",
     "ext-iconv": "*",

--- a/src/Cli/Executable.php
+++ b/src/Cli/Executable.php
@@ -77,7 +77,7 @@ abstract class Executable
      * @param Colors|null  $colors    Optional. Instance of the Colors object to use. Defaults to null to instantiate a
      *                                new one.
      */
-    public function __construct($autocatch = true, Options $options = null, Colors $colors = null)
+    public function __construct($autocatch = true, ?Options $options = null, ?Colors $colors = null)
     {
         if ($autocatch) {
             set_exception_handler([$this, 'fatal']);

--- a/src/Cli/Options.php
+++ b/src/Cli/Options.php
@@ -77,7 +77,7 @@ class Options
      * @param Colors $colors Optional. Configured color object.
      * @throws InvalidArgument When arguments can't be read.
      */
-    public function __construct(Colors $colors = null)
+    public function __construct(?Colors $colors = null)
     {
         $this->colors = $colors instanceof Colors ? $colors : new Colors();
 

--- a/src/Cli/TableFormatter.php
+++ b/src/Cli/TableFormatter.php
@@ -74,7 +74,7 @@ class TableFormatter
      *
      * @param Colors|null $colors Optional. Instance of the Colors helper object.
      */
-    public function __construct(Colors $colors = null)
+    public function __construct(?Colors $colors = null)
     {
         // Try to get terminal width.
         $width = $this->getTerminalWidth();

--- a/src/CssLength.php
+++ b/src/CssLength.php
@@ -112,7 +112,7 @@ final class CssLength
         if (preg_match($pattern, $this->attrValue, $match)) {
             $this->isValid = true;
             $this->numeral = isset($match['numeral']) ? (float)$match['numeral'] : $this->numeral;
-            $this->unit    = isset($match['unit']) ? $match['unit'] : $this->unit;
+            $this->unit    = $match['unit'] ?? $this->unit;
         }
     }
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -227,7 +227,7 @@ final class Document extends DOMDocument
             $options = [Option::ENCODING => $options];
         }
 
-        $encoding = isset($options[Option::ENCODING]) ? $options[Option::ENCODING] : null;
+        $encoding = $options[ Option::ENCODING ] ?? null;
 
         $dom = new self('', $encoding);
 
@@ -258,7 +258,7 @@ final class Document extends DOMDocument
             $options = [Option::ENCODING => $options];
         }
 
-        $encoding = isset($options[Option::ENCODING]) ? $options[Option::ENCODING] : null;
+        $encoding = $options[ Option::ENCODING ] ?? null;
 
         $dom = new self('', $encoding);
 
@@ -551,7 +551,7 @@ final class Document extends DOMDocument
             $content   = preg_replace(self::HTML_STRUCTURE_HTML_START_TAG, '', $content, 1);
 
             preg_match(self::HTML_STRUCTURE_HTML_END_TAG, $content, $matches);
-            $htmlEnd = isset($matches['html_end']) ? $matches['html_end'] : $htmlEnd;
+            $htmlEnd = $matches['html_end'] ?? $htmlEnd;
             $content = preg_replace(self::HTML_STRUCTURE_HTML_END_TAG, '', $content, 1);
         }
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -413,7 +413,7 @@ final class Document extends DOMDocument
      * @return string The HTML, or false if an error occurred.
      */
     #[\ReturnTypeWillChange]
-    public function saveHTML(DOMNode $node = null)
+    public function saveHTML(?DOMNode $node = null)
     {
         return $this->saveHTMLFragment($node);
     }
@@ -424,7 +424,7 @@ final class Document extends DOMDocument
      * @param DOMNode|null $node Optional. Parameter to output a subset of the document.
      * @return string The HTML fragment, or false if an error occurred.
      */
-    public function saveHTMLFragment(DOMNode $node = null)
+    public function saveHTMLFragment(?DOMNode $node = null)
     {
         $filtersInReverse = array_reverse($this->filters);
 

--- a/src/Dom/Document/Filter/AmpBindAttributes.php
+++ b/src/Dom/Document/Filter/AmpBindAttributes.php
@@ -215,7 +215,7 @@ final class AmpBindAttributes implements BeforeLoadFilter, AfterSaveFilter
                     ||
                     in_array($attrName, $this->convertedAmpBindAttributes, true)
                 ) {
-                    $attrValue = isset($attrMatches['value']) ? $attrMatches['value'] : '=""';
+                    $attrValue = $attrMatches['value'] ?? '=""';
                     $newAttrs .= " [{$attrName}]{$attrValue}";
                 } else {
                     $newAttrs .= $attrMatches[0];

--- a/src/Dom/Options.php
+++ b/src/Dom/Options.php
@@ -72,7 +72,7 @@ final class Options implements ArrayAccess
     #[\ReturnTypeWillChange]
     public function offsetGet($option)
     {
-        return isset($this->options[$option]) ? $this->options[$option] : null;
+        return $this->options[ $option ] ?? null;
     }
 
     /**

--- a/src/Optimizer/Error/CannotPreloadImage.php
+++ b/src/Optimizer/Error/CannotPreloadImage.php
@@ -25,7 +25,7 @@ final class CannotPreloadImage implements Error
      * @param Element|null $element Optional. Image element that has the srcset attribute, or null if no element.
      * @return self
      */
-    public static function fromImageWithSrcsetAttribute(Element $element = null)
+    public static function fromImageWithSrcsetAttribute(?Element $element = null)
     {
         $message = self::SRCSET_STRING;
 

--- a/src/Optimizer/TransformationEngine.php
+++ b/src/Optimizer/TransformationEngine.php
@@ -58,7 +58,7 @@ final class TransformationEngine
         ?RemoteGetRequest $remoteRequest = null,
         ?Spec $spec = null
     ) {
-        $this->configuration = isset($configuration) ? $configuration : new DefaultConfiguration();
+        $this->configuration = $configuration ?? new DefaultConfiguration();
         $this->remoteRequest = $remoteRequest;
         $this->spec          = $spec;
 

--- a/src/Optimizer/TransformationEngine.php
+++ b/src/Optimizer/TransformationEngine.php
@@ -51,7 +51,7 @@ final class TransformationEngine
      * @param Configuration|null    $configuration Optional. Configuration data to use for setting up the transformers.
      * @param RemoteGetRequest|null $remoteRequest Optional. Transport to use for remote requests. Defaults to the
      *                                             CurlRemoteGetRequest implementation shipped with the library.
-     * @param Spec                  $spec          Optional. Validator spec instance to use.
+     * @param Spec|null             $spec          Optional. Validator spec instance to use.
      */
     public function __construct(
         ?Configuration $configuration = null,

--- a/src/Optimizer/TransformationEngine.php
+++ b/src/Optimizer/TransformationEngine.php
@@ -54,9 +54,9 @@ final class TransformationEngine
      * @param Spec                  $spec          Optional. Validator spec instance to use.
      */
     public function __construct(
-        Configuration $configuration = null,
-        RemoteGetRequest $remoteRequest = null,
-        Spec $spec = null
+        ?Configuration $configuration = null,
+        ?RemoteGetRequest $remoteRequest = null,
+        ?Spec $spec = null
     ) {
         $this->configuration = isset($configuration) ? $configuration : new DefaultConfiguration();
         $this->remoteRequest = $remoteRequest;

--- a/src/Url.php
+++ b/src/Url.php
@@ -138,7 +138,7 @@ final class Url
      * @param Url|null    $baseUrl Base URL.
      * @throws FailedToParseUrl Exception when the URL or Base URL is malformed.
      */
-    public function __construct($url = null, Url $baseUrl = null)
+    public function __construct($url = null, ?Url $baseUrl = null)
     {
         $parsedUrl = [];
 

--- a/src/Validator/ValidationHandler.php
+++ b/src/Validator/ValidationHandler.php
@@ -56,7 +56,7 @@ final class ValidationHandler implements HtmlSaxHandlerWithLocation
      */
     private $validationResult;
 
-    public function __construct($htmlFormat = Format::AMP, Spec $spec = null)
+    public function __construct($htmlFormat = Format::AMP, ?Spec $spec = null)
     {
         $this->htmlFormat       = $htmlFormat;
         $this->spec             = $spec instanceof Spec ? $spec : new Spec();

--- a/src/Validator/ValidationResult.php
+++ b/src/Validator/ValidationResult.php
@@ -85,8 +85,8 @@ final class ValidationResult
      *                                                        array.
      */
     public function __construct(
-        ValidationStatus $status = null,
-        ValidationErrorCollection $errors = null,
+        ?ValidationStatus $status = null,
+        ?ValidationErrorCollection $errors = null,
         $specRevision = -1,
         $transformerVersion = 0,
         $typeIdentifiers = [],

--- a/src/Validator/ValidatorRules.php
+++ b/src/Validator/ValidatorRules.php
@@ -72,7 +72,7 @@ final class ValidatorRules
      * @param string    $htmlFormat Optional. AMP HTML format to validate against.
      * @param Spec|null $spec       Optional. Validator specification to use.
      */
-    public function __construct($htmlFormat = Format::AMP, Spec $spec = null)
+    public function __construct($htmlFormat = Format::AMP, ?Spec $spec = null)
     {
         $this->htmlFormat = $htmlFormat;
         $this->spec       = $spec instanceof Spec ? $spec : new Spec();

--- a/tests/Optimizer/TransformationEngineTest.php
+++ b/tests/Optimizer/TransformationEngineTest.php
@@ -132,7 +132,7 @@ final class TransformationEngineTest extends TestCase
      * @param Configuration|null $configuration Optional. Configuration object to use.
      * @return TransformationEngine Transformation engine instance to test against.
      */
-    private function getTransformationEngine(Configuration $configuration = null)
+    private function getTransformationEngine(?Configuration $configuration = null)
     {
         return new TransformationEngine(
             $configuration,


### PR DESCRIPTION
PHP 8.4 is slated to be released on November 21, 2024.

In the process of making the Web Stories plugin compatible, this addresses warnings about implicit nullable types.

PHP requirement is increased to 7.4 to make maintenance easier.

Fixes #549